### PR TITLE
Delegated Staking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,6 +2824,7 @@ dependencies = [
  "futures-util",
  "log",
  "ore-api",
+ "ore-boost-api",
  "ore-pool-api",
  "ore-utils",
  "postgres-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,8 +2739,6 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "ore-api"
 version = "2.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f004e50a7fba301eb53caa4f8ce772c1a512f314de64cff580f90fb1dff8d1"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",
@@ -2759,8 +2757,6 @@ dependencies = [
 [[package]]
 name = "ore-boost-api"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ca0476ddcacccdc2787d78f4a81ecd68ca251013126a1af7b53842bced5fd6"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",
@@ -2847,8 +2843,6 @@ dependencies = [
 [[package]]
 name = "ore-utils"
 version = "2.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d6933b14c84fb91ad7ab2e8fccff589884a81507c1a198dea4f03f3180ef4"
 dependencies = [
  "bytemuck",
  "solana-program",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2978,6 +2978,7 @@ dependencies = [
 name = "ore-pool-program"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "bytemuck",
  "drillx",
  "mpl-token-metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,8 +229,11 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 name = "admin"
 version = "0.1.0"
 dependencies = [
+ "ore-api",
  "ore-pool-api",
+ "ore-utils",
  "solana-client",
+ "solana-program",
  "solana-sdk",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,8 +64,8 @@ dependencies = [
  "encoding_rs",
  "flate2",
  "futures-core",
- "h2",
- "http",
+ "h2 0.3.26",
+ "http 0.2.12",
  "httparse",
  "httpdate",
  "itoa",
@@ -101,7 +101,7 @@ checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
 dependencies = [
  "bytestring",
  "cfg-if",
- "http",
+ "http 0.2.12",
  "regex",
  "regex-lite",
  "serde",
@@ -629,6 +629,12 @@ dependencies = [
  "quote",
  "syn 2.0.72",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -1733,6 +1739,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,7 +1926,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.3.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.3.0",
  "slab",
  "tokio",
@@ -2042,13 +2082,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2080,9 +2154,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2095,17 +2169,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.30",
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2506,6 +2635,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2731,10 +2877,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ore-api"
@@ -2829,6 +3013,7 @@ dependencies = [
  "ore-utils",
  "postgres-types",
  "rand 0.8.5",
+ "reqwest 0.12.4",
  "serde",
  "serde_json",
  "sha3 0.10.8",
@@ -3358,10 +3543,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -3371,7 +3556,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3386,7 +3571,49 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 0.25.4",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.1.3",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -3502,7 +3729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "schannel",
  "security-framework",
 ]
@@ -3515,6 +3742,22 @@ checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
 
 [[package]]
 name = "rustls-webpki"
@@ -3991,7 +4234,7 @@ dependencies = [
  "gethostname",
  "lazy_static",
  "log",
- "reqwest",
+ "reqwest 0.11.27",
  "solana-sdk",
  "thiserror",
 ]
@@ -4139,7 +4382,7 @@ dependencies = [
  "crossbeam-channel",
  "futures-util",
  "log",
- "reqwest",
+ "reqwest 0.11.27",
  "semver",
  "serde",
  "serde_derive",
@@ -4223,7 +4466,7 @@ dependencies = [
  "bs58",
  "indicatif",
  "log",
- "reqwest",
+ "reqwest 0.11.27",
  "semver",
  "serde",
  "serde_derive",
@@ -4246,7 +4489,7 @@ dependencies = [
  "base64 0.21.7",
  "bs58",
  "jsonrpc-core",
- "reqwest",
+ "reqwest 0.11.27",
  "semver",
  "serde",
  "serde_derive",
@@ -5061,6 +5304,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-postgres"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5225,7 +5478,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -5354,6 +5607,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -5715,6 +5974,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["solana", "crypto", "mining"]
 actix-cors = "0.7"
 actix-web = "4.9"
 array-const-fn-init = "0.1.1"
+base64 = "0.22.1"
 bincode = "1.3.3"
 bytemuck = "1.14.3"
 const-crypto = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,14 @@ futures-util = "0.3"
 log = "0.4"
 mpl-token-metadata = "4.1.2"
 num_enum = "0.7.2"
-ore-api = "2.1.9"
-ore-boost-api = "0.1.0"
+## ore-api = "2.1.9"
+## ore-boost-api = "0.1.0"
+## ore-pool-api = { path = "api", version = "0.1.0" }
+## ore-utils = { features = ["spl"], version = "2.1.9" }
+ore-api = { path = "../ore/api" }
+ore-boost-api = { path = "../ore-boost/api" }
 ore-pool-api = { path = "api", version = "0.1.0" }
-ore-utils = { features = ["spl"], version = "2.1.9" }
+ore-utils = { features = ["spl"], path = "../ore/utils" }
 postgres-types = { featuers = ["derive"], version = "0.2.6" }
 serde = { features = ["derive"], version = "1.0" }
 serde_json = "1.0"
@@ -41,7 +45,9 @@ solana-program = "^1.18"
 solana-sdk = "^1.18"
 solana-transaction-status = "^1.18"
 spl-token = { features = ["no-entrypoint"], version = "^4" }
-spl-associated-token-account = { features = ["no-entrypoint"], version = "^2.3" }
+spl-associated-token-account = { features = [
+  "no-entrypoint",
+], version = "^2.3" }
 static_assertions = "1.1.0"
 thiserror = "1.0.57"
 tokio = "1.39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ ore-boost-api = { path = "../ore-boost/api" }
 ore-pool-api = { path = "api", version = "0.1.0" }
 ore-utils = { features = ["spl"], path = "../ore/utils" }
 postgres-types = { featuers = ["derive"], version = "0.2.6" }
+reqwest = { version = "0.12", features = ["json"] }
 serde = { features = ["derive"], version = "1.0" }
 serde_json = "1.0"
 sha3 = "0.10"

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -10,8 +10,11 @@ readme.workspace = true
 keywords.workspace = true
 
 [dependencies]
+ore-api.workspace = true
 ore-pool-api.workspace = true
+ore-utils.workspace = true
 solana-sdk.workspace = true
 solana-client.workspace = true
+solana-program.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/admin/src/error.rs
+++ b/admin/src/error.rs
@@ -10,6 +10,8 @@ pub enum Error {
     PoolApi(#[from] ore_pool_api::error::ApiError),
     #[error("solana client")]
     SolanaClient(#[from] solana_client::client_error::ClientError),
+    #[error("solana program")]
+    SolaanProgram(#[from] solana_program::program_error::ProgramError),
     #[error("solana parse pubkey")]
     SolanaParsePubkey(#[from] solana_sdk::pubkey::ParsePubkeyError),
     #[error("missing boost mint")]

--- a/admin/src/error.rs
+++ b/admin/src/error.rs
@@ -6,10 +6,16 @@ pub enum Error {
     StdEnv(#[from] VarError),
     #[error("could not ready keypair from provided path: {0}")]
     KeypairRead(String),
-    #[error("pool api error")]
+    #[error("pool api")]
     PoolApi(#[from] ore_pool_api::error::ApiError),
-    #[error("solana client error")]
+    #[error("solana client")]
     SolanaClient(#[from] solana_client::client_error::ClientError),
+    #[error("solana parse pubkey")]
+    SolanaParsePubkey(#[from] solana_sdk::pubkey::ParsePubkeyError),
+    #[error("missing boost mint")]
+    MissingBoostMint,
+    #[error("missing pool url")]
+    MissingPoolUrl,
     #[error("invalid command")]
     InvalidCommand,
 }

--- a/admin/src/error.rs
+++ b/admin/src/error.rs
@@ -10,4 +10,6 @@ pub enum Error {
     PoolApi(#[from] ore_pool_api::error::ApiError),
     #[error("solana client error")]
     SolanaClient(#[from] solana_client::client_error::ClientError),
+    #[error("invalid command")]
+    InvalidCommand,
 }

--- a/admin/src/init.rs
+++ b/admin/src/init.rs
@@ -1,0 +1,19 @@
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::{signature::Keypair, signer::Signer, transaction::Transaction};
+
+use crate::error::Error;
+
+pub async fn init(
+    rpc_client: &RpcClient,
+    keypair: &Keypair,
+    pool_url: String,
+) -> Result<(), Error> {
+    let pubkey = keypair.pubkey();
+    let ix = ore_pool_api::sdk::launch(pubkey, pubkey, pool_url)?;
+    let hash = rpc_client.get_latest_blockhash().await?;
+    let mut tx = Transaction::new_with_payer(&[ix], Some(&pubkey));
+    tx.sign(&[keypair], hash);
+    let sig = rpc_client.send_transaction(&tx).await?;
+    println!("{:?}", sig);
+    Ok(())
+}

--- a/admin/src/main.rs
+++ b/admin/src/main.rs
@@ -8,6 +8,7 @@ use solana_sdk::{
 mod error;
 mod init;
 mod open_stake;
+mod proof_account;
 
 #[tokio::main]
 async fn main() -> Result<(), error::Error> {
@@ -21,6 +22,7 @@ async fn main() -> Result<(), error::Error> {
     match command.as_str() {
         "init" => init::init(&rpc_client, &keypair, pool_url).await,
         "open-stake" => open_stake::open_stake(&rpc_client, &keypair, boost_mint).await,
+        "proof-account" => proof_account::proof_account(&rpc_client, &keypair).await,
         _ => Err(error::Error::InvalidCommand),
     }
 }

--- a/admin/src/open_stake.rs
+++ b/admin/src/open_stake.rs
@@ -1,18 +1,18 @@
 use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{signature::Keypair, signer::Signer, transaction::Transaction};
+use solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::Signer, transaction::Transaction};
 
 use crate::error::Error;
 
-pub async fn init(
+pub async fn open_stake(
     rpc_client: &RpcClient,
     keypair: &Keypair,
-    pool_url: Option<String>,
+    mint: Option<Pubkey>,
 ) -> Result<(), Error> {
-    let pool_url = pool_url.ok_or(Error::MissingPoolUrl)?;
+    let mint = mint.ok_or(Error::MissingBoostMint)?;
     let pubkey = keypair.pubkey();
-    let ix = ore_pool_api::sdk::launch(pubkey, pubkey, pool_url)?;
-    let hash = rpc_client.get_latest_blockhash().await?;
+    let ix = ore_pool_api::sdk::open_stake(pubkey, mint);
     let mut tx = Transaction::new_with_payer(&[ix], Some(&pubkey));
+    let hash = rpc_client.get_latest_blockhash().await?;
     tx.sign(&[keypair], hash);
     let sig = rpc_client.send_transaction(&tx).await?;
     println!("{:?}", sig);

--- a/admin/src/proof_account.rs
+++ b/admin/src/proof_account.rs
@@ -1,0 +1,16 @@
+use ore_api::state::Proof;
+use ore_utils::AccountDeserialize;
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::{signature::Keypair, signer::Signer};
+
+use crate::error::Error;
+
+pub async fn proof_account(rpc_client: &RpcClient, keypair: &Keypair) -> Result<(), Error> {
+    let (pool_pda, _) = ore_pool_api::state::pool_pda(keypair.pubkey());
+    let (proof_pda, _) = ore_pool_api::state::pool_proof_pda(pool_pda);
+    let proof = rpc_client.get_account_data(&proof_pda).await?;
+    let proof = Proof::try_from_bytes(proof.as_slice())?;
+    println!("proof address: {:?}", proof_pda);
+    println!("proof: {:?}", proof);
+    Ok(())
+}

--- a/api/src/event.rs
+++ b/api/src/event.rs
@@ -1,0 +1,18 @@
+use bytemuck::{Pod, Zeroable};
+use ore_utils::event;
+use solana_program::pubkey::Pubkey;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
+pub struct StakeEvent {
+    /// the authority of the share account
+    pub authority: Pubkey,
+    /// the share account
+    pub share: Pubkey,
+    /// the mint (target of the staking)
+    pub mint: Pubkey,
+    /// latest balance
+    pub balance: u64,
+}
+
+event!(StakeEvent);

--- a/api/src/event.rs
+++ b/api/src/event.rs
@@ -4,7 +4,7 @@ use solana_program::pubkey::Pubkey;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
-pub struct StakeEvent {
+pub struct UnstakeEvent {
     /// the authority of the share account
     pub authority: Pubkey,
     /// the share account
@@ -15,4 +15,4 @@ pub struct StakeEvent {
     pub balance: u64,
 }
 
-event!(StakeEvent);
+event!(UnstakeEvent);

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod consts;
 pub mod error;
+pub mod event;
 pub mod instruction;
 pub mod loaders;
 pub mod sdk;

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -7,4 +7,4 @@ pub mod state;
 
 use solana_program::declare_id;
 
-declare_id!("EqLLh5fkFC9Aypo593qwgQLVDc66L72WxJTjuh94T3Mo");
+declare_id!("3kkUYuMeGP9BcMkec9Poji9CAcKrMUHxgxyJRiXz11yz");

--- a/api/src/sdk.rs
+++ b/api/src/sdk.rs
@@ -144,7 +144,7 @@ pub fn open_stake(signer: Pubkey, mint: Pubkey) -> Instruction {
     let (boost_pda, _) = ore_boost_api::state::boost_pda(mint);
     let (pool_pda, _) = pool_pda(signer);
     let pool_tokens = spl_associated_token_account::get_associated_token_address(&pool_pda, &mint);
-    let (stake_pda, _) = ore_boost_api::state::stake_pda(signer, boost_pda);
+    let (stake_pda, _) = ore_boost_api::state::stake_pda(pool_pda, boost_pda);
     Instruction {
         program_id: crate::id(),
         accounts: vec![

--- a/api/src/sdk.rs
+++ b/api/src/sdk.rs
@@ -106,6 +106,31 @@ pub fn attribute(signer: Pubkey, member_authority: Pubkey, total_balance: u64) -
     }
 }
 
+/// Builds a commit instruction.
+pub fn commit(signer: Pubkey, mint: Pubkey) -> Instruction {
+    let (boost_pda, _) = ore_boost_api::state::boost_pda(mint);
+    let boost_tokens =
+        spl_associated_token_account::get_associated_token_address(&boost_pda, &mint);
+    let (pool_pda, _) = pool_pda(signer);
+    let pool_tokens = spl_associated_token_account::get_associated_token_address(&pool_pda, &mint);
+    let (stake_pda, _) = ore_boost_api::state::stake_pda(pool_pda, boost_pda);
+    Instruction {
+        program_id: crate::id(),
+        accounts: vec![
+            AccountMeta::new(signer, true),
+            AccountMeta::new(boost_pda, false),
+            AccountMeta::new(boost_tokens, false),
+            AccountMeta::new_readonly(mint, false),
+            AccountMeta::new(pool_pda, false),
+            AccountMeta::new(pool_tokens, false),
+            AccountMeta::new(stake_pda, false),
+            AccountMeta::new_readonly(spl_token::id(), false),
+            AccountMeta::new_readonly(ore_boost_api::id(), false),
+        ],
+        data: Commit {}.to_bytes(),
+    }
+}
+
 /// Builds an submit instruction.
 pub fn submit(
     signer: Pubkey,

--- a/api/src/sdk.rs
+++ b/api/src/sdk.rs
@@ -137,22 +137,29 @@ pub fn submit(
     solution: Solution,
     attestation: [u8; 32],
     bus: Pubkey,
+    boost_accounts: Vec<Pubkey>,
 ) -> Instruction {
     let (pool_pda, _) = pool_pda(signer);
     let (proof_pda, _) = pool_proof_pda(pool_pda);
+    let accounts = vec![
+        AccountMeta::new(signer, true),
+        AccountMeta::new(bus, false),
+        AccountMeta::new_readonly(CONFIG_ADDRESS, false),
+        AccountMeta::new(pool_pda, false),
+        AccountMeta::new(proof_pda, false),
+        AccountMeta::new_readonly(ore_api::id(), false),
+        AccountMeta::new_readonly(system_program::id(), false),
+        AccountMeta::new_readonly(instructions::id(), false),
+        AccountMeta::new_readonly(slot_hashes::id(), false),
+    ];
+    let boost_accounts = boost_accounts
+        .into_iter()
+        .map(|pk| AccountMeta::new_readonly(pk, false))
+        .collect();
+    let accounts = [accounts, boost_accounts].concat();
     Instruction {
         program_id: crate::id(),
-        accounts: vec![
-            AccountMeta::new(signer, true),
-            AccountMeta::new(bus, false),
-            AccountMeta::new_readonly(CONFIG_ADDRESS, false),
-            AccountMeta::new(pool_pda, false),
-            AccountMeta::new(proof_pda, false),
-            AccountMeta::new_readonly(ore_api::id(), false),
-            AccountMeta::new_readonly(system_program::id(), false),
-            AccountMeta::new_readonly(instructions::id(), false),
-            AccountMeta::new_readonly(slot_hashes::id(), false),
-        ],
+        accounts,
         data: Submit {
             attestation,
             digest: solution.d,

--- a/api/src/sdk.rs
+++ b/api/src/sdk.rs
@@ -184,15 +184,6 @@ pub fn unstake(
     let pool_tokens = spl_associated_token_account::get_associated_token_address(&pool, &mint);
     let (share_pda, _) = share_pda(signer, pool, mint);
     let (stake_pda, _) = ore_boost_api::state::stake_pda(pool, boost_pda);
-    println!("boost: {:?}", boost_pda);
-    println!("boost tokens: {:?}", boost_tokens);
-    println!("member: {:?}", member_pda);
-    println!("pool tokens: {:?}", pool_tokens);
-    println!("share: {:?}", share_pda);
-    println!("stake: {:?}", stake_pda);
-    println!("mint: {:?}", mint);
-    println!("pool: {:?}", pool);
-    println!("recipient: {:?}", recipient);
     Instruction {
         program_id: crate::id(),
         accounts: vec![

--- a/api/src/sdk.rs
+++ b/api/src/sdk.rs
@@ -169,6 +169,54 @@ pub fn submit(
     }
 }
 
+/// builds an unstake instruction.
+pub fn unstake(
+    signer: Pubkey,
+    mint: Pubkey,
+    pool: Pubkey,
+    recipient: Pubkey,
+    amount: u64,
+) -> Instruction {
+    let (boost_pda, _) = ore_boost_api::state::boost_pda(mint);
+    let boost_tokens =
+        spl_associated_token_account::get_associated_token_address(&boost_pda, &mint);
+    let (member_pda, _) = member_pda(signer, pool);
+    let pool_tokens = spl_associated_token_account::get_associated_token_address(&pool, &mint);
+    let (share_pda, _) = share_pda(signer, pool, mint);
+    let (stake_pda, _) = ore_boost_api::state::stake_pda(pool, boost_pda);
+    println!("boost: {:?}", boost_pda);
+    println!("boost tokens: {:?}", boost_tokens);
+    println!("member: {:?}", member_pda);
+    println!("pool tokens: {:?}", pool_tokens);
+    println!("share: {:?}", share_pda);
+    println!("stake: {:?}", stake_pda);
+    println!("mint: {:?}", mint);
+    println!("pool: {:?}", pool);
+    println!("recipient: {:?}", recipient);
+    Instruction {
+        program_id: crate::id(),
+        accounts: vec![
+            AccountMeta::new(signer, true),
+            AccountMeta::new(boost_pda, false),
+            AccountMeta::new(boost_tokens, false),
+            AccountMeta::new_readonly(mint, false),
+            AccountMeta::new_readonly(member_pda, false),
+            AccountMeta::new(pool, false),
+            AccountMeta::new(pool_tokens, false),
+            AccountMeta::new(recipient, false),
+            AccountMeta::new(share_pda, false),
+            AccountMeta::new(stake_pda, false),
+            AccountMeta::new_readonly(spl_token::id(), false),
+            AccountMeta::new_readonly(ore_boost_api::id(), false),
+        ],
+        data: Unstake {
+            amount: amount.to_le_bytes(),
+        }
+        .to_bytes(),
+    }
+}
+
+/// builds a stake instruction.
 pub fn stake(
     signer: Pubkey,
     mint: Pubkey,

--- a/api/src/sdk.rs
+++ b/api/src/sdk.rs
@@ -139,6 +139,30 @@ pub fn submit(
     }
 }
 
+/// Builds an open stake instruction.
+pub fn open_stake(signer: Pubkey, mint: Pubkey) -> Instruction {
+    let (boost_pda, _) = ore_boost_api::state::boost_pda(mint);
+    let (pool_pda, _) = pool_pda(signer);
+    let pool_tokens = spl_associated_token_account::get_associated_token_address(&pool_pda, &mint);
+    let (stake_pda, _) = ore_boost_api::state::stake_pda(signer, boost_pda);
+    Instruction {
+        program_id: crate::id(),
+        accounts: vec![
+            AccountMeta::new(signer, true),
+            AccountMeta::new_readonly(boost_pda, false),
+            AccountMeta::new_readonly(mint, false),
+            AccountMeta::new(pool_pda, false),
+            AccountMeta::new(pool_tokens, false),
+            AccountMeta::new(stake_pda, false),
+            AccountMeta::new_readonly(system_program::id(), false),
+            AccountMeta::new_readonly(spl_token::id(), false),
+            AccountMeta::new_readonly(spl_associated_token_account::id(), false),
+            AccountMeta::new_readonly(ore_boost_api::id(), false),
+        ],
+        data: OpenStake {}.to_bytes(),
+    }
+}
+
 fn url_to_bytes(input: &str) -> Result<[u8; 128], ApiError> {
     let bytes = input.as_bytes();
     let len = bytes.len();

--- a/init-db/01_setup.sql
+++ b/init-db/01_setup.sql
@@ -1,4 +1,4 @@
--- create table
+-- create members table
 DO $$
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'members') THEN
@@ -10,7 +10,22 @@ BEGIN
           total_balance BIGINT NOT NULL,
           is_approved BOOLEAN NOT NULL,
           is_kyc BOOLEAN NOT NULL,
-          is_synced BOOLEAN NOT NULL
+          is_synced BOOLEAN NOT NULL,
+          CONSTRAINT unique_member_id UNIQUE (id)
+        );
+    END IF;
+END
+$$;
+
+-- create stakers table
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'stakers') THEN
+        CREATE TABLE stakers (
+          address VARCHAR PRIMARY KEY, -- address of share account
+          member_id BIGINT NOT NULL,
+          mint VARCHAR NOT NULL, -- the mint of the boost account
+          FOREIGN KEY (member_id) REFERENCES members(id)
         );
     END IF;
 END

--- a/init-db/01_setup.sql
+++ b/init-db/01_setup.sql
@@ -25,6 +25,7 @@ BEGIN
           address VARCHAR PRIMARY KEY, -- address of share account
           member_id BIGINT NOT NULL,
           mint VARCHAR NOT NULL, -- the mint of the boost account
+          webhook BOOLEAN NOT NULL, -- whether or not the address has been added to the webhook
           FOREIGN KEY (member_id) REFERENCES members(id)
         );
     END IF;

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "lib"]
 default = []
 
 [dependencies]
+base64.workspace = true
 bytemuck.workspace = true
 drillx.workspace = true
 mpl-token-metadata.workspace = true

--- a/program/src/claim.rs
+++ b/program/src/claim.rs
@@ -45,7 +45,7 @@ pub fn process_claim(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult
     let pool_authority = pool.authority;
     drop(pool_data);
     solana_program::program::invoke_signed(
-        &ore_api::instruction::claim(*pool_info.key, *beneficiary_info.key, amount),
+        &ore_api::sdk::claim(*pool_info.key, *beneficiary_info.key, amount),
         &[
             pool_info.clone(),
             beneficiary_info.clone(),

--- a/program/src/commit.rs
+++ b/program/src/commit.rs
@@ -3,24 +3,23 @@ use ore_pool_api::{consts::POOL, loaders::*, state::Pool};
 use ore_utils::*;
 use solana_program::{
     self, account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
-    program_pack::Pack, system_program,
+    program_pack::Pack,
 };
 
 /// Commit pending stake from the pool program into the boost program.
 pub fn process_commit(accounts: &[AccountInfo<'_>], _data: &[u8]) -> ProgramResult {
     // Load accounts.
-    let [signer, boost_info, boost_tokens_info, mint_info, pool_info, pool_tokens_info, stake_info, system_program, spl_token_program, ore_boost_program] =
+    let [signer, boost_info, boost_tokens_info, mint_info, pool_info, pool_tokens_info, stake_info, spl_token_program, ore_boost_program] =
         accounts
     else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
     load_signer(signer)?;
-    load_boost(boost_info, mint_info.key, false)?;
+    load_boost(boost_info, mint_info.key, true)?;
     load_associated_token_account(boost_tokens_info, boost_info.key, mint_info.key, true)?;
     load_any_mint(mint_info, false)?;
-    load_pool(pool_info, signer.key, false)?;
+    load_pool(pool_info, signer.key, true)?;
     load_associated_token_account(pool_tokens_info, pool_info.key, mint_info.key, true)?;
-    load_program(system_program, system_program::id())?;
     load_program(spl_token_program, spl_token::id())?;
     load_program(ore_boost_program, ore_boost_api::id())?;
 
@@ -46,7 +45,6 @@ pub fn process_commit(accounts: &[AccountInfo<'_>], _data: &[u8]) -> ProgramResu
             mint_info.clone(),
             pool_tokens_info.clone(),
             stake_info.clone(),
-            system_program.clone(),
             spl_token_program.clone(),
         ],
         &[&[POOL, signer.key.as_ref(), &[pool_bump]]],

--- a/program/src/launch.rs
+++ b/program/src/launch.rs
@@ -54,7 +54,7 @@ pub fn process_launch(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResul
 
     // Open proof account.
     solana_program::program::invoke_signed(
-        &ore_api::instruction::open(*pool_info.key, *miner_info.key, *signer.key),
+        &ore_api::sdk::open(*pool_info.key, *miner_info.key, *signer.key),
         &[
             pool_info.clone(),
             miner_info.clone(),

--- a/program/src/open_share.rs
+++ b/program/src/open_share.rs
@@ -1,7 +1,7 @@
 use std::mem::size_of;
 
 use ore_boost_api::loaders::{load_boost, load_stake};
-use ore_pool_api::{consts::*, instruction::OpenShare, loaders::load_pool, state::Share};
+use ore_pool_api::{consts::*, instruction::OpenShare, loaders::load_any_pool, state::Share};
 use ore_utils::*;
 use solana_program::{
     self, account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
@@ -22,7 +22,7 @@ pub fn process_open_share(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramR
     load_signer(signer)?;
     load_boost(boost_info, mint_info.key, false)?;
     load_any_mint(mint_info, false)?;
-    load_pool(pool_info, signer.key, false)?;
+    load_any_pool(pool_info, false)?;
     load_uninitialized_pda(
         share_info,
         &[

--- a/program/src/open_share.rs
+++ b/program/src/open_share.rs
@@ -22,7 +22,7 @@ pub fn process_open_share(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramR
     load_signer(signer)?;
     load_boost(boost_info, mint_info.key, false)?;
     load_any_mint(mint_info, false)?;
-    load_pool(pool_info, signer.key, true)?;
+    load_pool(pool_info, signer.key, false)?;
     load_uninitialized_pda(
         share_info,
         &[

--- a/program/src/open_stake.rs
+++ b/program/src/open_stake.rs
@@ -33,9 +33,10 @@ pub fn process_open_stake(accounts: &[AccountInfo<'_>], _data: &[u8]) -> Program
 
     // Open the stake account.
     invoke_signed(
-        &ore_boost_api::sdk::open(*pool_info.key, *mint_info.key),
+        &ore_boost_api::sdk::open(*pool_info.key, *signer.key, *mint_info.key),
         &[
             pool_info.clone(),
+            signer.clone(),
             boost_info.clone(),
             mint_info.clone(),
             stake_info.clone(),

--- a/program/src/stake.rs
+++ b/program/src/stake.rs
@@ -1,10 +1,8 @@
-use base64::{prelude::BASE64_STANDARD, Engine};
 use ore_api::instruction::Stake;
-use ore_pool_api::{event::StakeEvent, loaders::*, state::Share};
+use ore_pool_api::{loaders::*, state::Share};
 use ore_utils::*;
 use solana_program::{
-    self, account_info::AccountInfo, entrypoint::ProgramResult, log::sol_log,
-    program_error::ProgramError,
+    self, account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
 };
 
 /// Deposit tokens into a pool's pending stake account.
@@ -41,17 +39,6 @@ pub fn process_stake(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult
         token_program,
         amount,
     )?;
-
-    // Log the balance for parsing.
-    let event = StakeEvent {
-        authority: *signer.key,
-        share: *share_info.key,
-        mint: *mint_info.key,
-        balance: share.balance,
-    };
-    let event = event.to_bytes();
-    let event = BASE64_STANDARD.encode(event);
-    sol_log(event.as_str());
 
     Ok(())
 }

--- a/program/src/stake.rs
+++ b/program/src/stake.rs
@@ -1,8 +1,10 @@
+use base64::{prelude::BASE64_STANDARD, Engine};
 use ore_api::instruction::Stake;
-use ore_pool_api::{loaders::*, state::Share};
+use ore_pool_api::{event::StakeEvent, loaders::*, state::Share};
 use ore_utils::*;
 use solana_program::{
-    self, account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
+    self, account_info::AccountInfo, entrypoint::ProgramResult, log::sol_log,
+    program_error::ProgramError,
 };
 
 /// Deposit tokens into a pool's pending stake account.
@@ -39,6 +41,17 @@ pub fn process_stake(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult
         token_program,
         amount,
     )?;
+
+    // Log the balance for parsing.
+    let event = StakeEvent {
+        authority: *signer.key,
+        share: *share_info.key,
+        mint: *mint_info.key,
+        balance: share.balance,
+    };
+    let event = event.to_bytes();
+    let event = BASE64_STANDARD.encode(event);
+    sol_log(event.as_str());
 
     Ok(())
 }

--- a/program/src/submit.rs
+++ b/program/src/submit.rs
@@ -58,8 +58,15 @@ pub fn process_submit(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResul
         slot_hashes_sysvar.clone(),
     ];
     let mine_accounts = [mine_accounts, optional_accounts].concat();
+    let optional_accounts = optional_accounts.iter().map(|a| *a.key).collect();
     solana_program::program::invoke(
-        &ore_api::sdk::mine(*signer.key, *pool_info.key, *bus_info.key, solution),
+        &ore_api::sdk::mine(
+            *signer.key,
+            *pool_info.key,
+            *bus_info.key,
+            solution,
+            optional_accounts,
+        ),
         &mine_accounts,
     )?;
 

--- a/program/src/submit.rs
+++ b/program/src/submit.rs
@@ -49,7 +49,7 @@ pub fn process_submit(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResul
     // Submit solution to the ORE program
     let solution = Solution::new(args.digest, args.nonce);
     solana_program::program::invoke(
-        &ore_api::instruction::mine(*signer.key, *pool_info.key, *bus_info.key, solution),
+        &ore_api::sdk::mine(*signer.key, *pool_info.key, *bus_info.key, solution),
         &[
             signer.clone(),
             bus_info.clone(),

--- a/server/.env.example
+++ b/server/.env.example
@@ -2,3 +2,6 @@ KEYPAIR_PATH="/etc/secrets/ore-pool-authority.json"
 DB_URL=""
 RPC_URL=""
 ATTR_EPOCH="" // how often the attribution loop submits (in minutes)
+STAKE_EPOCH="" // how often the stake loop commits (in minutes)
+HELIUS_API_KEY="" // for programatically updating webhooks
+HELIUS_AUTH_HEADER="" // auth header token we give to helius to write webhook POST events

--- a/server/.env.example
+++ b/server/.env.example
@@ -4,4 +4,4 @@ RPC_URL=""
 ATTR_EPOCH="" // how often the attribution loop submits (in minutes)
 STAKE_EPOCH="" // how often the stake loop commits (in minutes)
 HELIUS_API_KEY="" // for programatically updating webhooks
-HELIUS_AUTH_HEADER="" // auth header token we give to helius to write webhook POST events
+HELIUS_AUTH_TOKEN="" // auth header token we give to helius to write webhook POST events

--- a/server/.env.example
+++ b/server/.env.example
@@ -5,3 +5,7 @@ ATTR_EPOCH="" // how often the attribution loop submits (in minutes)
 STAKE_EPOCH="" // how often the stake loop commits (in minutes)
 HELIUS_API_KEY="" // for programatically updating webhooks
 HELIUS_AUTH_TOKEN="" // auth header token we give to helius to write webhook POST events
+HELIUS_WEBHOOK_ID_STAKE="" // id of helius webhook for listening to share accounts
+BOOST_ONE="" // optional boost account to accept stake for from clients
+BOOST_TWO="" // optional boost account to accept stake for from clients
+BOOST_THREE="" // optional boost account to accept stake for from clients

--- a/server/.env.example
+++ b/server/.env.example
@@ -6,6 +6,7 @@ STAKE_EPOCH="" // how often the stake loop commits (in minutes)
 HELIUS_API_KEY="" // for programatically updating webhooks
 HELIUS_AUTH_TOKEN="" // auth header token we give to helius to write webhook POST events
 HELIUS_WEBHOOK_ID_STAKE="" // id of helius webhook for listening to share accounts
+HELIUS_WEBHOOK_URL="" // the /webhook path that your server exposes to helius
 BOOST_ONE="" // optional boost account to accept stake for from clients
 BOOST_TWO="" // optional boost account to accept stake for from clients
 BOOST_THREE="" // optional boost account to accept stake for from clients

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 actix-cors = { workspace = true }
 actix-web = { workspace = true }
+base64 = { workspace = true }
 bincode = { workspace = true }
 bytemuck = { workspace = true }
 deadpool-postgres = { workspace = true }
@@ -32,4 +33,3 @@ tokio = { workspace = true }
 tokio-postgres = { workspace = true }
 types = { path = "../types" }
 rand = "0.8.5"
-base64 = "0.22.1"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,6 +16,7 @@ futures-channel = { workspace = true }
 futures-util = { workspace = true }
 log = { workspace = true }
 ore-api = { workspace = true }
+ore-boost-api = { workspace = true }
 ore-utils = { workspace = true }
 ore-pool-api = { workspace = true }
 postgres-types = { workspace = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -20,6 +20,7 @@ ore-boost-api = { workspace = true }
 ore-utils = { workspace = true }
 ore-pool-api = { workspace = true }
 postgres-types = { workspace = true }
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha3 = { workspace = true }

--- a/server/src/aggregator.rs
+++ b/server/src/aggregator.rs
@@ -205,7 +205,7 @@ impl Aggregator {
         let (pool_proof_pda, _) = ore_pool_api::state::pool_proof_pda(pool_pda);
         let bus = self.find_bus(operator).await?;
         // build instructions
-        let auth_ix = ore_api::instruction::auth(pool_proof_pda);
+        let auth_ix = ore_api::sdk::auth(pool_proof_pda);
         let submit_ix =
             ore_pool_api::sdk::submit(operator.keypair.pubkey(), best_solution, attestation, bus);
         let rpc_client = &operator.rpc_client;

--- a/server/src/aggregator.rs
+++ b/server/src/aggregator.rs
@@ -42,18 +42,8 @@ pub struct Aggregator {
     /// The number of workers that have been approved for the current challenge.
     pub num_members: u64,
 
-    /// The map of stake contributors to be attributed.
-    pub stake: Stake,
-}
-
-pub struct Stake {
-    /// The active map of stake.
-    /// Decrements can be made at any time.
-    pub active: HashMap<Pubkey, u64>,
-
-    /// The pending map of stake.
-    /// Increments are synced at the commit loop.
-    pub pending: HashMap<Pubkey, u64>,
+    /// The map of stake contributors for attribution.
+    pub stake: HashMap<Pubkey, u64>,
 }
 
 // Best hash to be submitted for the current challenge.
@@ -175,10 +165,7 @@ impl Aggregator {
             num_members: pool.last_total_members,
             // TODO: fetch stake addresses from db
             // fetch onchain accounts in batch
-            stake: Stake {
-                active: HashMap::new(),
-                pending: HashMap::new(),
-            },
+            stake: HashMap::new(),
         };
         Ok(aggregator)
     }

--- a/server/src/aggregator.rs
+++ b/server/src/aggregator.rs
@@ -252,7 +252,7 @@ impl Aggregator {
             .recv()
             .await
             .ok_or(Error::Internal("rewards channel closed".to_string()))?;
-        log::info!("reward: {}", rewards.base);
+        log::info!("reward: {:?}", rewards);
         let rewards_distribution = self.rewards_distribution(pool_pda, rewards.base);
         // write rewards to db
         let mut db_client = operator.db_client.get().await?;

--- a/server/src/aggregator.rs
+++ b/server/src/aggregator.rs
@@ -206,8 +206,13 @@ impl Aggregator {
         let bus = self.find_bus(operator).await?;
         // build instructions
         let auth_ix = ore_api::sdk::auth(pool_proof_pda);
-        let submit_ix =
-            ore_pool_api::sdk::submit(operator.keypair.pubkey(), best_solution, attestation, bus);
+        let submit_ix = ore_pool_api::sdk::submit(
+            operator.keypair.pubkey(),
+            best_solution,
+            attestation,
+            bus,
+            operator.get_boost_mine_accounts(),
+        );
         let rpc_client = &operator.rpc_client;
         let sig = tx::submit::submit_and_confirm_instructions(
             &operator.keypair,

--- a/server/src/contributor.rs
+++ b/server/src/contributor.rs
@@ -229,7 +229,6 @@ async fn register_new_staker(
                             share: staker.1,
                             authority: member_authority,
                             mint,
-                            share_account: staker.0,
                         };
                         webhook_client.put(operator, aggregator, &entry).await?;
                     }
@@ -247,7 +246,6 @@ async fn register_new_staker(
                         share: staker.1,
                         authority: member_authority,
                         mint,
-                        share_account: staker.0,
                     };
                     webhook_client.put(operator, aggregator, &entry).await?;
                     Ok(db_staker)

--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -136,7 +136,7 @@ pub async fn write_webhook_staker(conn: &Object, share: &Pubkey) -> Result<(), E
     Ok(())
 }
 
-pub type StakersStream = Pin<Box<dyn Stream<Item = Result<Staker, Error>>>>;
+pub type StakersStream = Pin<Box<dyn Stream<Item = Result<Staker, Error>> + Send>>;
 pub async fn stream_stakers(conn: &Object, mint: &Pubkey) -> Result<StakersStream, Error> {
     let stmt = "SELECT address, member_id, mint, webhook FROM stakers WHERE mint = ANY($1)";
     let params: &[String] = &[mint.to_string()];

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -34,6 +34,8 @@ pub enum Error {
     MemberDoesNotExist,
     #[error("staker doesn't exist yet")]
     StakerDoesNotExist,
+    #[error("share account received")]
+    ShareAccountReceived,
     #[error("{0}")]
     Internal(String),
 }
@@ -44,6 +46,7 @@ impl From<Error> for HttpResponse {
             Error::MemberDoesNotExist | Error::StakerDoesNotExist => {
                 HttpResponse::NotFound().finish()
             }
+            Error::ShareAccountReceived => HttpResponse::Ok().finish(),
             _ => HttpResponse::InternalServerError().finish(),
         }
     }

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -1,5 +1,7 @@
 use actix_web::{http::header::ToStrError, HttpResponse};
 
+use crate::webhook;
+
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("bincode")]
@@ -8,6 +10,8 @@ pub enum Error {
     Base64Decode(#[from] base64::DecodeError),
     #[error("try from slice")]
     TryFromSlice(#[from] std::array::TryFromSliceError),
+    #[error("rewards channel send")]
+    RewardsChannelSend(#[from] tokio::sync::mpsc::error::SendError<webhook::Rewards>),
     #[error("tokio postgres")]
     TokioPostgres(#[from] tokio_postgres::Error),
     #[error("deadpool postgress")]
@@ -36,6 +40,8 @@ pub enum Error {
     StakerDoesNotExist,
     #[error("share account received")]
     ShareAccountReceived,
+    #[error("proof account received")]
+    ProofAccountReceived,
     #[error("{0}")]
     Internal(String),
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -87,6 +87,7 @@ async fn main() -> Result<(), error::Error> {
             .app_data(operator.clone())
             .app_data(aggregator.clone())
             .app_data(webhook_handler.clone())
+            .app_data(webhook_client.clone())
             .service(web::resource("/member/{authority}").route(web::get().to(contributor::member)))
             .service(web::resource("/pool-address").route(web::get().to(contributor::pool_address)))
             .service(web::resource("/register").route(web::post().to(contributor::register)))

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -17,6 +17,7 @@ use utils::create_cors;
 // write attestation url to db with last-hash-at as foreign key
 #[actix_web::main]
 async fn main() -> Result<(), error::Error> {
+    env_logger::init();
     // operator and aggregator mutex
     let operator = web::Data::new(Operator::new()?);
     let aggregator = tokio::sync::RwLock::new(Aggregator::new(&operator).await?);
@@ -59,7 +60,6 @@ async fn main() -> Result<(), error::Error> {
 
     // launch server
     HttpServer::new(move || {
-        env_logger::init();
         log::info!("starting server");
         App::new()
             .wrap(middleware::Logger::default())

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -7,10 +7,12 @@ mod tx;
 mod utils;
 
 use core::panic;
+use std::str::FromStr;
 
 use actix_web::{get, middleware, web, App, HttpResponse, HttpServer, Responder};
 use aggregator::{Aggregator, Contribution};
 use operator::Operator;
+use solana_sdk::pubkey::Pubkey;
 use utils::create_cors;
 
 // TODO: publish attestation to s3
@@ -27,6 +29,8 @@ async fn main() -> Result<(), error::Error> {
     let tx = web::Data::new(tx);
     // env vars
     let attribution_epoch = attribution_epoch()?;
+    let stake_commit_epoch = stake_commit_epoch()?;
+    let boosts = load_boosts()?;
 
     // aggregate contributions
     tokio::task::spawn({
@@ -52,8 +56,26 @@ async fn main() -> Result<(), error::Error> {
                 if let Err(err) = operator.attribute_members().await {
                     panic!("{:?}", err)
                 }
-                // sleep until next attribution epoch
+                // sleep until next epoch
                 tokio::time::sleep(tokio::time::Duration::from_secs(60 * attribution_epoch)).await;
+            }
+        }
+    });
+
+    // kick off commit-stake loop
+    tokio::task::spawn({
+        let operator = operator.clone();
+        async move {
+            if boosts.len().gt(&0) {
+                loop {
+                    let operator = operator.clone().into_inner();
+                    if let Err(err) = operator.commit_stake(boosts.as_slice()).await {
+                        panic!("{:?}", err)
+                    }
+                    // sleep until next epoch
+                    tokio::time::sleep(tokio::time::Duration::from_secs(60 * stake_commit_epoch))
+                        .await;
+                }
             }
         }
     });
@@ -81,6 +103,47 @@ async fn main() -> Result<(), error::Error> {
     .run()
     .await
     .map_err(From::from)
+}
+
+fn load_boosts() -> Result<Vec<Pubkey>, error::Error> {
+    let boost_1 = boost_one()?;
+    let boost_2 = boost_two()?;
+    let boost_3 = boost_three()?;
+    let boosts: Vec<Pubkey> = vec![boost_1, boost_2, boost_3]
+        .into_iter()
+        .flatten()
+        .collect();
+    Ok(boosts)
+}
+
+fn load_boost(var: String) -> Result<Option<Pubkey>, error::Error> {
+    match std::env::var(var) {
+        Ok(boost) => {
+            let boost = Pubkey::from_str(boost.as_str())?;
+            Ok(Some(boost))
+        }
+        // optional
+        Err(_) => Ok(None),
+    }
+}
+
+fn boost_one() -> Result<Option<Pubkey>, error::Error> {
+    load_boost("BOOST_ONE".to_string())
+}
+
+fn boost_two() -> Result<Option<Pubkey>, error::Error> {
+    load_boost("BOOST_TWO".to_string())
+}
+
+fn boost_three() -> Result<Option<Pubkey>, error::Error> {
+    load_boost("BOOST_THREE".to_string())
+}
+
+// denominated in minutes
+fn stake_commit_epoch() -> Result<u64, error::Error> {
+    let string = std::env::var("STAKE_EPOCH")?;
+    let epoch: u64 = string.parse()?;
+    Ok(epoch)
 }
 
 // denominated in minutes

--- a/server/src/operator.rs
+++ b/server/src/operator.rs
@@ -137,7 +137,7 @@ impl Operator {
     pub async fn get_stakers_onchain(&self, mint: &Pubkey) -> Result<HashMap<Pubkey, u64>, Error> {
         let rpc_client = &self.rpc_client;
         let vec = self.get_stakers_db(mint).await?;
-        let mut queries: Vec<Pin<Box<dyn Future<Output = GetManyStakers>>>> = vec![];
+        let mut queries: Vec<Pin<Box<dyn Future<Output = GetManyStakers> + Send>>> = vec![];
         for chunk in vec.chunks(100) {
             let query = rpc_client
                 .get_multiple_accounts(chunk)
@@ -217,7 +217,7 @@ impl Operator {
         Ok(())
     }
 
-    pub async fn commit_stake(self: Arc<Self>) -> Result<(), Error> {
+    pub async fn commit_stake(&self) -> Result<(), Error> {
         let authority = &self.keypair;
         let rpc_client = &self.rpc_client;
         let boost_mints = self.get_boosts();

--- a/server/src/webhook.rs
+++ b/server/src/webhook.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use solana_sdk::pubkey::Pubkey;
 
-use crate::error::Error;
+use crate::{aggregator::Aggregator, error::Error};
 
 const HELIUS_URL: &str = "https://api.helius.xyz";
 const HELIUS_WEBHOOK_API_PATH: &str = "v0/webhooks";
@@ -97,8 +97,16 @@ impl Client {
         Ok(s)
     }
 
+    pub async fn put(
+        &self,
+        aggregator: &tokio::sync::RwLock<Aggregator>,
+        address: Pubkey,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
     /// edit the listen-for accounts by passing the entire collection
-    pub async fn edit(&self, account_addresses: Vec<Pubkey>) -> Result<(), Error> {
+    async fn edit(&self, account_addresses: Vec<Pubkey>) -> Result<(), Error> {
         // const response = await fetch('https://api.helius.xyz/v0/webhooks/{webhookID}?api-key=text', {
         let edit_url = format!(
             "{}/{}/{}?{}",

--- a/server/src/webhook.rs
+++ b/server/src/webhook.rs
@@ -107,10 +107,6 @@ impl Handle {
         let mut event = self.decode_share_account_event(req, bytes).await?;
         self.process_share_account_event(aggregator, &mut event)
             .await?;
-        let stakers = &aggregator.read().await.stake;
-        for s in stakers.iter() {
-            log::info!("staker: {:?}", s);
-        }
         Ok(())
     }
 

--- a/server/src/webhook.rs
+++ b/server/src/webhook.rs
@@ -157,7 +157,7 @@ fn helius_api_key() -> Result<String, Error> {
 }
 
 fn helius_auth_token() -> Result<String, Error> {
-    std::env::var("HELIUS_AUTH_TOAUTH_TOKEN").map_err(From::from)
+    std::env::var("HELIUS_AUTH_TOKEN").map_err(From::from)
 }
 
 fn helius_webhook_id_stake() -> Result<String, Error> {

--- a/server/src/webhook.rs
+++ b/server/src/webhook.rs
@@ -314,6 +314,7 @@ impl Client {
         // insert into staker balancers
         let stakers = &mut write.stake;
         if let std::collections::hash_map::Entry::Vacant(vacant) = stakers.entry(entry.authority) {
+            // TODO; insert as zero regardless of balance. increments are handled on submit loops.
             vacant.insert(entry.share_account.balance);
         }
         Ok(())

--- a/server/src/webhook.rs
+++ b/server/src/webhook.rs
@@ -1,0 +1,132 @@
+use std::collections::HashMap;
+
+use actix_web::{web, HttpRequest, HttpResponse, Responder};
+use solana_sdk::pubkey::Pubkey;
+
+use crate::error::Error;
+
+const HELIUS_URL: &str = "https://api.helius.xyz";
+const HELIUS_WEBHOOK_API_PATH: &str = "v0/webhooks";
+
+/// client for managing helius webhooks
+pub struct Client {
+    http_client: reqwest::Client,
+    /// query paramter added to the url for making http requets to helius.
+    helius_api_key: String,
+    /// the helius webhook id created in the console
+    /// for tracking share accounts
+    helius_webhook_id_stake: String,
+}
+
+/// handler for receiving helius webhook events
+pub struct Handle {
+    /// the auth token expected to be included in webhook events
+    /// posted from helius to our server.
+    helius_auth_token: String,
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct EditSuccess {
+    #[serde(rename = "webhookID")]
+    webhook_id: String,
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct ShareAccountEvent {}
+
+impl Handle {
+    pub fn new() -> Result<Self, Error> {
+        let helius_auth_token = helius_auth_token()?;
+        let s = Self { helius_auth_token };
+        Ok(s)
+    }
+
+    pub async fn share_account(
+        handle: web::Data<Handle>,
+        req: HttpRequest,
+        bytes: web::Bytes,
+    ) -> impl Responder {
+        let handle = handle.into_inner();
+        match handle.handle_share_account_event(&req, &bytes).await {
+            Ok(()) => HttpResponse::Ok().finish(),
+            Err(err) => {
+                log::error!("{:?}", err);
+                HttpResponse::InternalServerError().body(err.to_string())
+            }
+        }
+    }
+
+    /// process the share account event
+    async fn handle_share_account_event(
+        &self,
+        req: &HttpRequest,
+        bytes: &web::Bytes,
+    ) -> Result<(), Error> {
+        self.auth(req)?;
+        let bytes = bytes.to_vec();
+        let event = serde_json::from_slice::<ShareAccountEvent>(bytes.as_slice())?;
+        log::info!("share account event: {:?}", event);
+        Ok(())
+    }
+
+    /// parse and validate the auth header
+    fn auth(&self, req: &HttpRequest) -> Result<(), Error> {
+        let header = req.headers().get("Authorization").ok_or(Error::Internal(
+            "missing auth header in webhook event".to_string(),
+        ))?;
+        let header = header.to_str()?;
+        if header.to_string().ne(&self.helius_auth_token) {
+            return Err(Error::Internal(
+                "invalid auth header in webhook event".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Client {
+    /// create new client for listening to share account state changes
+    pub fn new_stake() -> Result<Self, Error> {
+        let helius_api_key = helius_api_key()?;
+        let helius_webhook_id_stake = helius_webhook_id_stake()?;
+        let s = Self {
+            http_client: reqwest::Client::new(),
+            helius_api_key,
+            helius_webhook_id_stake,
+        };
+        Ok(s)
+    }
+
+    /// edit the listen-for accounts by passing the entire collection
+    pub async fn edit(&self, account_addresses: Vec<Pubkey>) -> Result<(), Error> {
+        // const response = await fetch('https://api.helius.xyz/v0/webhooks/{webhookID}?api-key=text', {
+        let edit_url = format!(
+            "{}/{}/{}?{}",
+            HELIUS_URL, HELIUS_WEBHOOK_API_PATH, self.helius_webhook_id_stake, self.helius_api_key
+        );
+        let mut json = HashMap::<String, Vec<Pubkey>>::new();
+        json.insert("accountAddresses".to_string(), account_addresses);
+        let resp = self
+            .http_client
+            .put(edit_url)
+            .json(&json)
+            .send()
+            .await?
+            .json::<EditSuccess>()
+            .await?;
+        log::info!("edit: {:?}", resp);
+        Ok(())
+    }
+}
+
+fn helius_api_key() -> Result<String, Error> {
+    std::env::var("HELIUS_API_KEY").map_err(From::from)
+}
+
+fn helius_auth_token() -> Result<String, Error> {
+    std::env::var("HELIUS_AUTH_TOAUTH_TOKEN").map_err(From::from)
+}
+
+fn helius_webhook_id_stake() -> Result<String, Error> {
+    std::env::var("HELIUS_WEBHOOK_ID_STAKE").map_err(From::from)
+}

--- a/server/src/webhook.rs
+++ b/server/src/webhook.rs
@@ -36,7 +36,6 @@ pub struct ClientPutEntry {
     pub share: Pubkey,
     pub authority: Pubkey,
     pub mint: Pubkey,
-    pub share_account: ore_pool_api::state::Share,
 }
 
 /// the PUT edit payload, idempotent
@@ -314,8 +313,8 @@ impl Client {
         // insert into staker balancers
         let stakers = &mut write.stake;
         if let std::collections::hash_map::Entry::Vacant(vacant) = stakers.entry(entry.authority) {
-            // TODO; insert as zero regardless of balance. increments are handled on submit loops.
-            vacant.insert(entry.share_account.balance);
+            // insert as zero regardless of balance. increments are handled on submit loops.
+            vacant.insert(0);
         }
         Ok(())
     }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -78,45 +78,61 @@ pub struct Challenge {
     pub cutoff_time: u64,
 }
 
-// The member record that sits in the operator database
+/// The member record that sits in the operator database
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Member {
-    // The respective pda pubkey of the on-chain account.
+    /// The respective pda pubkey of the on-chain account.
     pub address: String,
 
-    // The id as assigned by the on-chain program.
+    /// The id as assigned by the on-chain program.
     pub id: i64,
 
-    // The authority pubkey of this account.
+    /// The authority pubkey of this account.
     pub authority: String,
 
-    // The pool pubkey this account belongs to.
+    /// The pool pubkey this account belongs to.
     pub pool_address: String,
 
-    // The total balance assigned to this account.
-    // Always increments for idempotent on-chain updates.
+    /// The total balance assigned to this account.
+    /// Always increments for idempotent on-chain updates.
     pub total_balance: i64,
 
-    // Whether or not this member is approved by the operator.
+    /// Whether or not this member is approved by the operator.
     pub is_approved: bool,
 
-    // Whether or not this member is KYC'd by the operator.
+    /// Whether or not this member is KYC'd by the operator.
     pub is_kyc: bool,
 
-    // Whether or not this member's on-chain balance is in sync with the operator db balance.
+    /// Whether or not this member's on-chain balance is in sync with the operator db balance.
     pub is_synced: bool,
 }
 
-// The response from the /challenge request.
+/// The staker record that sits in the operator database
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Staker {
+    /// the share account address
+    pub address: Pubkey,
+
+    /// the member id (foreign key relation to members table)
+    pub member_id: u64,
+
+    /// the mint of the boost account the member is staking to
+    pub mint: Pubkey,
+
+    /// whether or not this account has been added to the webhook
+    pub webhook: bool,
+}
+
+/// The response from the /challenge request.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MemberChallenge {
-    // The challenge to mine for.
+    /// The challenge to mine for.
     pub challenge: Challenge,
 
-    // Additional seconds to be subtracted from the cuttoff time
-    // to create a "submission window".
+    /// Additional seconds to be subtracted from the cuttoff time
+    /// to create a "submission window".
     pub buffer: u64,
 
-    // The number of total members to divide the nonce space by.
+    /// The number of total members to divide the nonce space by.
     pub num_total_members: u64,
 }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -42,6 +42,15 @@ pub struct UpdateBalancePayload {
     pub hash: Hash,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RegisterStakerPayload {
+    /// The authority of the member account sending the payload.
+    pub authority: Pubkey,
+
+    /// The mint for the boost account the member is staking to.
+    pub mint: Pubkey,
+}
+
 ///////////////////////////////////////////////////////////////////////////
 /// Response //////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The server tracks staker balances via webhook.

Decrements to the stake account are parsed by the server and updated in real-time via in-memory hash-map.

Increments to stake accounts are "ignored" by the server. But they're recorded on-chain.
There's a "commit stake" loop spawned from the main thread in the server. Every N minutes the server will commit all the pending stake to the pool's stake account. It then fetches all of the stake/share accounts that may have been incremented and updates their balances in-memory.

Fetching stake/share accounts from on-chain (on / after every commit loop) are done in concurrent batches of 100 -- the max supported by rpc.get-multiple-accounts.

Registered stakers are stored in the database. When a staker registers, the server will add/put their share address to the webhook.
A bool field is maintained in the database for idempotent puts to the webhook.

