### PR TITLE
Open Share and Stake

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,22 @@
 
 ## Admin
 - Must `cargo run` the [admin application](./admin/src/main.rs) before starting server.
-This creates the pool account on-chain which the server expects to exist upon starting.
+
+1) Create the pool account on-chain which the server expects to exist upon starting.
+```sh
+COMMAND="init" RPC_URL="" KEYPAIR_PATH="" POOL_URL="" cargo run --release
+```
+2) Create the stake account for each boost you want to support. Users can open share accounts that represent proportional shares in the total stake of the pool (per boost account).
+```sh
+COMMAND="open-stake" MINT="" RPC_URL="" KEYPAIR_PATH="" cargo run --release
+```
+
+## Server
+There are many parameters that the server supports via [env vars](./server/.env.example). 
+Including which boost accounts to support. How often to attribute members. And the webhook configuration.
+```sh
+RPC_URL="" KEYPAIR_PATH="" DB_URL="" ATTR_EPOCH="60" STAKE_EPOCH="60" BOOST_ONE="" HELIUS_API_KEY="" HELIUS_AUTH_TOKEN="" HELIUS_WEBHOOK_ID="" HELIUS_WEBHOOK_URL="" RUST_LOG=info cargo run --release
+```
 
 ## Considerations
 - This implementation is still in active development and is subject to breaking changes.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ COMMAND="open-stake" MINT="" RPC_URL="" KEYPAIR_PATH="" cargo run --release
 There are many parameters that the server supports via [env vars](./server/.env.example). 
 Including which boost accounts to support. How often to attribute members. And the webhook configuration.
 ```sh
-RPC_URL="" KEYPAIR_PATH="" DB_URL="" ATTR_EPOCH="60" STAKE_EPOCH="60" BOOST_ONE="" HELIUS_API_KEY="" HELIUS_AUTH_TOKEN="" HELIUS_WEBHOOK_ID="" HELIUS_WEBHOOK_URL="" RUST_LOG=info cargo run --release
+RPC_URL="" KEYPAIR_PATH="" DB_URL="" ATTR_EPOCH="60" STAKE_EPOCH="60" BOOST_ONE="" HELIUS_API_KEY="" HELIUS_AUTH_TOKEN="" HELIUS_WEBHOOK_ID="" HELIUS_WEBHOOK_URL="http://your-server.com/webhook/share-account" RUST_LOG=info cargo run --release
 ```
 
 ## Considerations

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ RPC_URL="" KEYPAIR_PATH="" DB_URL="" ATTR_EPOCH="60" STAKE_EPOCH="60" BOOST_ONE=
 - This implementation is still in active development and is subject to breaking changes.
 - The idea is for this to be a reference implementation for operators.
 - Feel free to fork this repo and add your custom logic.
-- We're trying to add parameters of interest as [environment variables](./server/.env.example), but you can always fork if we've missed something in the meantime.
 - Ofc we're accepting PRs / contributions. Please help us reach a solid v1.0.0.
 - This implementation is integrated with the official `ore-cli`.
 - So if you fork and change things, just make sure you serve the same HTTP paths that the `ore-cli` is interfacing with. If you do that, people should be able to participate in your pool with no additional installs or changes to their client.

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -18,4 +18,4 @@ pub mod prelude {
 
 use steel::*;
 
-declare_id!("3kkUYuMeGP9BcMkec9Poji9CAcKrMUHxgxyJRiXz11yz");
+declare_id!("APwnwBuRtLAN1Qk1fuZ5beXKfA5Efe9jK2ECd4c9o3E");

--- a/program/src/open_share.rs
+++ b/program/src/open_share.rs
@@ -15,8 +15,8 @@ pub fn process_open_share(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramR
     };
     signer_info.is_signer()?;
     boost_info
-        .to_account_mut::<Boost>(&ore_boost_api::ID)?
-        .check_mut(|b| b.mint == *mint_info.key)?;
+        .to_account::<Boost>(&ore_boost_api::ID)?
+        .check(|b| b.mint == *mint_info.key)?;
     mint_info.to_mint()?;
     pool_info.to_account::<Pool>(&ore_pool_api::ID)?;
     share_info.is_empty()?.is_writable()?.has_seeds(
@@ -51,7 +51,7 @@ pub fn process_open_share(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramR
     )?;
 
     // Initialize share account data.
-    let share = share_info.to_account_mut::<Share>(&ore_boost_api::ID)?;
+    let share = share_info.to_account_mut::<Share>(&ore_pool_api::ID)?;
     share.authority = *signer_info.key;
     share.balance = 0;
     share.pool = *pool_info.key;

--- a/program/src/stake.rs
+++ b/program/src/stake.rs
@@ -30,7 +30,7 @@ pub fn process_stake(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult
         .check(|t| t.mint == *mint_info.key)?;
     let share = share_info
         .to_account_mut::<Share>(&ore_pool_api::ID)?
-        .check_mut(|s| s.authority == *pool_info.key)?
+        .check_mut(|s| s.authority == *signer_info.key)?
         .check_mut(|s| s.mint == *mint_info.key)?;
     token_program.is_program(&spl_token::ID)?;
 

--- a/server/src/webhook.rs
+++ b/server/src/webhook.rs
@@ -17,7 +17,7 @@ pub struct Client {
     helius_api_key: String,
     /// the helius webhook id created in the console
     /// for tracking share accounts
-    helius_webhook_id_stake: String,
+    helius_webhook_id: String,
     /// the /webhook path that your server exposes to helius
     helius_webhook_url: String,
     /// the auth token expected to be included in webhook events
@@ -278,13 +278,13 @@ impl Client {
     /// create new client for listening to share account state changes
     pub fn new_stake() -> Result<Self, Error> {
         let helius_api_key = helius_api_key()?;
-        let helius_webhook_id_stake = helius_webhook_id_stake()?;
+        let helius_webhook_id = helius_webhook_id()?;
         let helius_webhook_url = helius_webhook_url()?;
         let helius_auth_token = helius_auth_token()?;
         let s = Self {
             http_client: reqwest::Client::new(),
             helius_api_key,
-            helius_webhook_id_stake,
+            helius_webhook_id,
             helius_webhook_url,
             helius_auth_token,
         };
@@ -323,7 +323,7 @@ impl Client {
     async fn edit(&self, account_addresses: Vec<String>) -> Result<ClientEditSuccess, Error> {
         let edit_url = format!(
             "{}/{}/{}?api-key={}",
-            HELIUS_URL, HELIUS_WEBHOOK_API_PATH, self.helius_webhook_id_stake, self.helius_api_key
+            HELIUS_URL, HELIUS_WEBHOOK_API_PATH, self.helius_webhook_id, self.helius_api_key
         );
         let webhook_url = self.helius_webhook_url.clone();
         let auth_header = self.helius_auth_token.clone();
@@ -359,6 +359,6 @@ fn helius_auth_token() -> Result<String, Error> {
     std::env::var("HELIUS_AUTH_TOKEN").map_err(From::from)
 }
 
-fn helius_webhook_id_stake() -> Result<String, Error> {
-    std::env::var("HELIUS_WEBHOOK_ID_STAKE").map_err(From::from)
+fn helius_webhook_id() -> Result<String, Error> {
+    std::env::var("HELIUS_WEBHOOK_ID").map_err(From::from)
 }


### PR DESCRIPTION
Redeployed program with new id.

Some impl bugs leaked in the migration to steel.

1) decoding the boost account as mut asserts the account as writable. The instruction doesn't actually mutate that account. And/so the instruction builder specifies that account-meta as read-only.

2) share account belongs to the pool program.

3) share account authority is the signer.

////////////////////////////////////////
Also added more documentation to the readme (unrelated).