### PR TITLE
Skip Confirmation

### DIFF
--- a/server/src/aggregator.rs
+++ b/server/src/aggregator.rs
@@ -282,7 +282,7 @@ impl Aggregator {
             operator.get_boost_mine_accounts(),
         );
         let rpc_client = &operator.rpc_client;
-        let sig = tx::submit::submit_and_confirm_instructions(
+        let sig = tx::submit::submit_instructions(
             &operator.keypair,
             rpc_client,
             &[auth_ix, submit_ix],


### PR DESCRIPTION
Skip confirmation of the submit instruction. Successfully fetching a new challenge implies confirmation. This may increase the likelihood of 0x5 (spam) errors. But those are caught by RPC simulation (no fees lost), and the server gracefully moves on when a new challenge is found.