### PR TITLE
Rewards Accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ name = "admin"
 version = "0.1.0"
 dependencies = [
  "ore-api",
+ "ore-boost-api",
  "ore-pool-api",
  "solana-client",
  "solana-program",
@@ -799,7 +800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1979,6 +1980,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2926,8 +2930,6 @@ dependencies = [
 [[package]]
 name = "ore-api"
 version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d87e900bb0b603d8b88a92639dae43eac4737acaef514af0de1c8598aed2eb"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",
@@ -2946,8 +2948,6 @@ dependencies = [
 [[package]]
 name = "ore-boost-api"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c97f55b9d1a40a6b3044444c457acd70b983d31b7edd5c8459b8c616b080fecd"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -1980,9 +1980,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2929,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "ore-api"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ futures-util = "0.3"
 log = "0.4"
 mpl-token-metadata = "4.1.2"
 num_enum = "0.7.2"
-ore-api = "2.3"
+ore-api = "2.4"
 ore-boost-api = "0.2"
 ore-pool-api = { path = "api", version = "0.1.0" }
 postgres-types = { featuers = ["derive"], version = "0.2.6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,6 @@ thiserror = "1.0.57"
 tokio = "1.39"
 tokio-postgres = "0.7"
 
-# [patch.crates-io]
-# ore-api = { path = "../ore/api" }
-# ore-boost-api = { path = "../ore-boost/api" }
+[patch.crates-io]
+ore-api = { path = "../ore/api" }
+ore-boost-api = { path = "../ore-boost/api" }

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -11,6 +11,7 @@ keywords.workspace = true
 
 [dependencies]
 ore-api.workspace = true
+ore-boost-api.workspace = true
 ore-pool-api.workspace = true
 solana-sdk.workspace = true
 solana-client.workspace = true

--- a/admin/src/get_or_create.rs
+++ b/admin/src/get_or_create.rs
@@ -1,0 +1,37 @@
+use std::fmt::Debug;
+
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::{signature::Keypair, signer::Signer, transaction::Transaction};
+use steel::{AccountDeserialize, Instruction, Pubkey};
+
+use crate::error::Error;
+
+pub async fn pda<T: AccountDeserialize + Debug>(
+    rpc_client: &RpcClient,
+    keypair: &Keypair,
+    pda: &Pubkey,
+    create_ix: Instruction,
+) -> Result<(), Error> {
+    let data = rpc_client.get_account_data(pda).await;
+    match data {
+        Err(_) => {
+            let mut tx = Transaction::new_with_payer(&[create_ix], Some(&keypair.pubkey()));
+            let hash = rpc_client.get_latest_blockhash().await?;
+            tx.sign(&[keypair], hash);
+            let sig = rpc_client.send_transaction(&tx).await?;
+            println!("{:?}", sig);
+            println!("sleeping for 10 seconds to allow rpc to catch up");
+            tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+            println!("fetching account");
+            let data = rpc_client.get_account_data(pda).await?;
+            let account: &T = AccountDeserialize::try_from_bytes(data.as_slice())?;
+            println!("{:?}", account);
+            Ok(())
+        }
+        Ok(data) => {
+            let account: &T = AccountDeserialize::try_from_bytes(data.as_slice())?;
+            println!("{:?}", account);
+            Ok(())
+        }
+    }
+}

--- a/admin/src/init.rs
+++ b/admin/src/init.rs
@@ -1,12 +1,8 @@
-use std::fmt::Debug;
-
-use ore_pool_api::state::{Member, Pool};
+use ore_pool_api::state::{Member, Pool, TotalRewards};
 use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_program::pubkey::Pubkey;
-use solana_sdk::{signature::Keypair, signer::Signer, transaction::Transaction};
-use steel::{AccountDeserialize, Instruction};
+use solana_sdk::{signature::Keypair, signer::Signer};
 
-use crate::error::Error;
+use crate::{error::Error, get_or_create};
 
 pub async fn init(
     rpc_client: &RpcClient,
@@ -20,41 +16,21 @@ pub async fn init(
     let (pool_pda, _) = ore_pool_api::state::pool_pda(pubkey);
     let launch_ix = ore_pool_api::sdk::launch(pubkey, pubkey, pool_url)?;
     println!("pool address: {:?}", pool_pda);
-    get_or_create_pda::<Pool>(rpc_client, keypair, &pool_pda, launch_ix).await?;
+    get_or_create::pda::<Pool>(rpc_client, keypair, &pool_pda, launch_ix).await?;
     // get or create member account
     let (member_pda, _) = ore_pool_api::state::member_pda(pubkey, pool_pda);
     let join_ix = ore_pool_api::sdk::join(pubkey, pool_pda, pubkey);
     println!("member address: {:?}", member_pda);
-    get_or_create_pda::<Member>(rpc_client, keypair, &member_pda, join_ix).await?;
+    get_or_create::pda::<Member>(rpc_client, keypair, &member_pda, join_ix).await?;
+    // get or create total rewards account
+    let (total_rewards_pda, _) = ore_pool_api::state::pool_total_rewards(pool_pda);
+    let open_total_rewards_ix = ore_pool_api::sdk::open_total_rewards(pubkey, pool_pda);
+    get_or_create::pda::<TotalRewards>(
+        rpc_client,
+        keypair,
+        &total_rewards_pda,
+        open_total_rewards_ix,
+    )
+    .await?;
     Ok(())
-}
-
-async fn get_or_create_pda<T: AccountDeserialize + Debug>(
-    rpc_client: &RpcClient,
-    keypair: &Keypair,
-    pda: &Pubkey,
-    create_ix: Instruction,
-) -> Result<(), Error> {
-    let data = rpc_client.get_account_data(pda).await;
-    match data {
-        Err(_) => {
-            let mut tx = Transaction::new_with_payer(&[create_ix], Some(&keypair.pubkey()));
-            let hash = rpc_client.get_latest_blockhash().await?;
-            tx.sign(&[keypair], hash);
-            let sig = rpc_client.send_transaction(&tx).await?;
-            println!("{:?}", sig);
-            println!("sleeping for 10 seconds to allow rpc to catch up");
-            tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
-            println!("fetching account");
-            let data = rpc_client.get_account_data(pda).await?;
-            let account: &T = AccountDeserialize::try_from_bytes(data.as_slice())?;
-            println!("{:?}", account);
-            Ok(())
-        }
-        Ok(data) => {
-            let account: &T = AccountDeserialize::try_from_bytes(data.as_slice())?;
-            println!("{:?}", account);
-            Ok(())
-        }
-    }
 }

--- a/admin/src/main.rs
+++ b/admin/src/main.rs
@@ -6,6 +6,7 @@ use solana_sdk::{
 };
 
 mod error;
+mod get_or_create;
 mod init;
 mod member_account;
 mod open_stake;

--- a/admin/src/open_stake.rs
+++ b/admin/src/open_stake.rs
@@ -13,9 +13,10 @@ pub async fn open_stake(
     let mint = mint.ok_or(Error::MissingBoostMint)?;
     let pubkey = keypair.pubkey();
     // get or create stake account
-    let (boost_pda, _) = ore_boost_api::state::boost_pda(mint);
-    let (stake_pda, _) = ore_boost_api::state::stake_pda(pubkey, boost_pda);
+    let (pool_pda, _) = ore_pool_api::state::pool_pda(pubkey);
+    let (stake_pda, _) = ore_pool_api::state::pool_stake_pda(pool_pda, mint);
     let open_stake_ix = ore_pool_api::sdk::open_stake(pubkey, mint);
+    println!("stake pda: {:?}", stake_pda);
     get_or_create::pda::<Stake>(rpc_client, keypair, &stake_pda, open_stake_ix).await?;
     // get or create share rewards account
     let (pool_pda, _) = ore_pool_api::state::pool_pda(pubkey);

--- a/api/src/consts.rs
+++ b/api/src/consts.rs
@@ -6,3 +6,8 @@ pub const POOL: &[u8] = b"pool";
 
 /// The seed of the share account PDA.
 pub const SHARE: &[u8] = b"share";
+
+/// The seed of the total rewrads account PDA.
+pub const TOTAL_REWARDS: &[u8] = b"total-rewards";
+
+pub const SHARE_REWARDS: &[u8] = b"share-rewards";

--- a/api/src/instruction.rs
+++ b/api/src/instruction.rs
@@ -16,6 +16,8 @@ pub enum PoolInstruction {
     Launch = 102,
     OpenStake = 103,
     Submit = 104,
+    OpenTotalRewards = 105,
+    OpenShareRewards = 106,
 }
 
 #[repr(C)]
@@ -79,6 +81,18 @@ pub struct Unstake {
     pub amount: [u8; 8],
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct OpenTotalRewards {
+    pub bump: u8,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct OpenShareRewards {
+    pub bump: u8,
+}
+
 instruction!(PoolInstruction, Attribute);
 instruction!(PoolInstruction, Claim);
 instruction!(PoolInstruction, Commit);
@@ -89,3 +103,5 @@ instruction!(PoolInstruction, Join);
 instruction!(PoolInstruction, Stake);
 instruction!(PoolInstruction, Submit);
 instruction!(PoolInstruction, Unstake);
+instruction!(PoolInstruction, OpenTotalRewards);
+instruction!(PoolInstruction, OpenShareRewards);

--- a/api/src/instruction.rs
+++ b/api/src/instruction.rs
@@ -18,6 +18,8 @@ pub enum PoolInstruction {
     Submit = 104,
     OpenTotalRewards = 105,
     OpenShareRewards = 106,
+    IncrementTotalRewards = 107,
+    IncrementShareRewards = 108,
 }
 
 #[repr(C)]
@@ -93,6 +95,20 @@ pub struct OpenShareRewards {
     pub bump: u8,
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct IncrementTotalRewards {
+    pub miner_rewards: [u8; 8],
+    pub staker_rewards: [u8; 8],
+    pub operator_rewards: [u8; 8],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct IncrementShareRewards {
+    pub rewards: [u8; 8],
+}
+
 instruction!(PoolInstruction, Attribute);
 instruction!(PoolInstruction, Claim);
 instruction!(PoolInstruction, Commit);
@@ -105,3 +121,5 @@ instruction!(PoolInstruction, Submit);
 instruction!(PoolInstruction, Unstake);
 instruction!(PoolInstruction, OpenTotalRewards);
 instruction!(PoolInstruction, OpenShareRewards);
+instruction!(PoolInstruction, IncrementTotalRewards);
+instruction!(PoolInstruction, IncrementShareRewards);

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -18,4 +18,4 @@ pub mod prelude {
 
 use steel::*;
 
-declare_id!("APwnwBuRtLAN1Qk1fuZ5beXKfA5Efe9jK2ECd4c9o3E");
+declare_id!("poo1sKMYsZtDDS7og73L68etJQYyn6KXhXTLz1hizJc");

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -18,4 +18,4 @@ pub mod prelude {
 
 use steel::*;
 
-declare_id!("poo1sKMYsZtDDS7og73L68etJQYyn6KXhXTLz1hizJc");
+declare_id!("APwnwBuRtLAN1Qk1fuZ5beXKfA5Efe9jK2ECd4c9o3E");

--- a/api/src/sdk.rs
+++ b/api/src/sdk.rs
@@ -6,7 +6,8 @@ use crate::{
     error::ApiError,
     instruction::*,
     state::{
-        member_pda, pool_pda, pool_proof_pda, pool_share_rewards_pda, pool_total_rewards, share_pda,
+        member_pda, pool_pda, pool_proof_pda, pool_share_rewards_pda, pool_stake_pda,
+        pool_total_rewards, share_pda,
     },
 };
 
@@ -338,7 +339,7 @@ pub fn open_stake(signer: Pubkey, mint: Pubkey) -> Instruction {
     let (boost_pda, _) = ore_boost_api::state::boost_pda(mint);
     let (pool_pda, _) = pool_pda(signer);
     let pool_tokens = spl_associated_token_account::get_associated_token_address(&pool_pda, &mint);
-    let (stake_pda, _) = ore_boost_api::state::stake_pda(pool_pda, boost_pda);
+    let (stake_pda, _) = pool_stake_pda(pool_pda, mint);
     Instruction {
         program_id: crate::ID,
         accounts: vec![

--- a/api/src/sdk.rs
+++ b/api/src/sdk.rs
@@ -5,7 +5,9 @@ use steel::*;
 use crate::{
     error::ApiError,
     instruction::*,
-    state::{member_pda, pool_pda, pool_proof_pda, share_pda},
+    state::{
+        member_pda, pool_pda, pool_proof_pda, pool_share_rewards_pda, pool_total_rewards, share_pda,
+    },
 };
 
 /// Builds a launch instruction.
@@ -229,6 +231,37 @@ pub fn stake(
             amount: amount.to_le_bytes(),
         }
         .to_bytes(),
+    }
+}
+
+/// Builds an open share rewards instruction.
+pub fn open_share_rewards(signer: Pubkey, pool: Pubkey, mint: Pubkey) -> Instruction {
+    let (share_rewards_pda, bump) = pool_share_rewards_pda(pool, mint);
+    Instruction {
+        program_id: crate::ID,
+        accounts: vec![
+            AccountMeta::new(signer, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new_readonly(mint, false),
+            AccountMeta::new(share_rewards_pda, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        data: OpenShareRewards { bump }.to_bytes(),
+    }
+}
+
+/// Builds an open total rewards instruction.
+pub fn open_total_rewards(signer: Pubkey, pool: Pubkey) -> Instruction {
+    let (total_rewards_pda, bump) = pool_total_rewards(pool);
+    Instruction {
+        program_id: crate::ID,
+        accounts: vec![
+            AccountMeta::new(signer, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new(total_rewards_pda, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        data: OpenTotalRewards { bump }.to_bytes(),
     }
 }
 

--- a/api/src/sdk.rs
+++ b/api/src/sdk.rs
@@ -234,6 +234,54 @@ pub fn stake(
     }
 }
 
+/// Builds an increment share rewards instruction.
+pub fn increment_share_rewards(
+    signer: Pubkey,
+    pool: Pubkey,
+    mint: Pubkey,
+    rewards: u64,
+) -> Instruction {
+    let (share_rewards_pda, _) = pool_share_rewards_pda(pool, mint);
+    Instruction {
+        program_id: crate::ID,
+        accounts: vec![
+            AccountMeta::new(signer, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new_readonly(mint, false),
+            AccountMeta::new(share_rewards_pda, false),
+        ],
+        data: IncrementShareRewards {
+            rewards: rewards.to_le_bytes(),
+        }
+        .to_bytes(),
+    }
+}
+
+///  Builds an increment total rewards instruction.
+pub fn increment_total_rewards(
+    signer: Pubkey,
+    pool: Pubkey,
+    miner_rewards: u64,
+    staker_rewards: u64,
+    operator_rewards: u64,
+) -> Instruction {
+    let (total_rewards_pda, _) = pool_total_rewards(pool);
+    Instruction {
+        program_id: crate::ID,
+        accounts: vec![
+            AccountMeta::new(signer, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new(total_rewards_pda, false),
+        ],
+        data: IncrementTotalRewards {
+            miner_rewards: miner_rewards.to_le_bytes(),
+            staker_rewards: staker_rewards.to_le_bytes(),
+            operator_rewards: operator_rewards.to_le_bytes(),
+        }
+        .to_bytes(),
+    }
+}
+
 /// Builds an open share rewards instruction.
 pub fn open_share_rewards(signer: Pubkey, pool: Pubkey, mint: Pubkey) -> Instruction {
     let (share_rewards_pda, bump) = pool_share_rewards_pda(pool, mint);

--- a/api/src/state/mod.rs
+++ b/api/src/state/mod.rs
@@ -1,9 +1,11 @@
 mod member;
 mod pool;
+mod rewards;
 mod share;
 
 pub use member::*;
 pub use pool::*;
+pub use rewards::*;
 pub use share::*;
 
 use steel::*;
@@ -16,8 +18,12 @@ pub enum AccountDiscriminator {
     Member = 100,
     Pool = 101,
     Share = 102,
+    TotalRewards = 103,
+    ShareRewards = 104,
 }
 
+/////////////////////////////////////////////////////////////////////////////////
+// pool accounts ////////////////////////////////////////////////////////////////
 pub fn pool_pda(authority: Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(&[POOL, authority.as_ref()], &crate::id())
 }
@@ -35,6 +41,17 @@ pub fn pool_stake_pda(pool: Pubkey, mint: Pubkey) -> (Pubkey, u8) {
     ore_boost_api::state::stake_pda(pool, boost_pda.0)
 }
 
+pub fn pool_total_rewards(pool: Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[TOTAL_REWARDS, pool.as_ref()], &crate::id())
+}
+
+pub fn pool_share_rewards_pda(pool: Pubkey, mint: Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[SHARE_REWARDS, pool.as_ref(), mint.as_ref()], &crate::id())
+}
+/////////////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////////////
+// member accounts //////////////////////////////////////////////////////////////
 pub fn member_pda(authority: Pubkey, pool: Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(&[MEMBER, authority.as_ref(), pool.as_ref()], &crate::id())
 }

--- a/api/src/state/rewards.rs
+++ b/api/src/state/rewards.rs
@@ -1,0 +1,37 @@
+use steel::*;
+
+use super::AccountDiscriminator;
+
+/// Tracks the lifetime rewards distributed in the pool amongst all the parties.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
+pub struct TotalRewards {
+    /// The pool the total rewards accounts are associated with.
+    pub pool: Pubkey,
+
+    /// The total lifetime rewards distributed to miners in the pool.
+    pub miner_rewards: u64,
+
+    /// The total lifetime rewards distributed to stakers in the pool.
+    pub staker_rewards: u64,
+
+    /// The total lifetime rewards distributed to the pool operator.
+    pub operator_rewards: u64,
+}
+
+/// Tracks the lifetime rewards distributed to share holders of a particular boost account.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
+pub struct ShareRewards {
+    /// The pool the share accounts are associated with.
+    pub pool: Pubkey,
+
+    /// The mint the share accounts are associated with.
+    pub mint: Pubkey,
+
+    /// The total rewards attributed to the share holders.
+    pub rewards: u64,
+}
+
+account!(AccountDiscriminator, TotalRewards);
+account!(AccountDiscriminator, ShareRewards);

--- a/init-db/01_setup.sql
+++ b/init-db/01_setup.sql
@@ -31,3 +31,34 @@ BEGIN
     END IF;
 END
 $$;
+
+-- create total-rewards table
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'total_rewards') THEN
+        CREATE TABLE total_rewards (
+            address VARCHAR PRIMARY KEY, -- unique address for the total rewards account
+            pool VARCHAR NOT NULL, -- pool associated with total rewards
+            miner_rewards BIGINT NOT NULL, -- total rewards for miners
+            staker_rewards BIGINT NOT NULL, -- total rewards for stakers
+            operator_rewards BIGINT NOT NULL, -- total rewards for the operator
+            is_synced BOOLEAN NOT NULL -- whether the total rewards account is synced
+        );
+    END IF;
+END
+$$;
+
+-- create share-rewards table
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'share_rewards') THEN
+        CREATE TABLE share_rewards (
+            address VARCHAR PRIMARY KEY, -- unique address for the share rewards account
+            pool VARCHAR NOT NULL, -- pool associated with share rewards
+            mint VARCHAR NOT NULL, -- mint associated with the share account
+            rewards BIGINT NOT NULL, -- total rewards for share holders
+            is_synced BOOLEAN NOT NULL -- whether the share rewards account is synced
+        );
+    END IF;
+END
+$$;

--- a/program/src/increment_share_rewards.rs
+++ b/program/src/increment_share_rewards.rs
@@ -1,0 +1,31 @@
+use ore_pool_api::{
+    instruction::IncrementShareRewards,
+    state::{Pool, ShareRewards},
+};
+use steel::*;
+
+pub fn process_increment_share_rewards(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
+    // Parse args.
+    let args = IncrementShareRewards::try_from_bytes(data)?;
+    let rewards = u64::from_le_bytes(args.rewards);
+
+    // Load accounts.
+    let [signer_info, pool_info, mint_info, share_rewards_info] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+    signer_info.is_signer()?;
+    pool_info
+        .to_account::<Pool>(&ore_pool_api::ID)?
+        .check(|p| p.authority == *signer_info.key)?;
+    mint_info.to_mint()?;
+    let share_rewards = share_rewards_info
+        .is_writable()?
+        .to_account_mut::<ShareRewards>(&ore_pool_api::ID)?
+        .check_mut(|sr| sr.pool == *pool_info.key)?
+        .check_mut(|sr| sr.mint == *mint_info.key)?;
+
+    // Update rewards.
+    share_rewards.rewards = rewards;
+
+    Ok(())
+}

--- a/program/src/increment_total_rewards.rs
+++ b/program/src/increment_total_rewards.rs
@@ -1,0 +1,33 @@
+use ore_pool_api::{
+    instruction::IncrementTotalRewards,
+    state::{Pool, TotalRewards},
+};
+use steel::*;
+
+pub fn process_increment_total_rewards(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
+    // Parse args.
+    let args = IncrementTotalRewards::try_from_bytes(data)?;
+    let miner_rewards = u64::from_le_bytes(args.miner_rewards);
+    let staker_rewards = u64::from_le_bytes(args.staker_rewards);
+    let operator_rewards = u64::from_le_bytes(args.operator_rewards);
+
+    // Load accounts.
+    let [signer_info, pool_info, total_rewards_info] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+    signer_info.is_signer()?;
+    pool_info
+        .to_account::<Pool>(&ore_pool_api::ID)?
+        .check(|p| p.authority == *signer_info.key)?;
+    let total_rewards = total_rewards_info
+        .is_writable()?
+        .to_account_mut::<TotalRewards>(&ore_pool_api::ID)?
+        .check_mut(|tr| tr.pool == *pool_info.key)?;
+
+    // Update rewards.
+    total_rewards.miner_rewards = miner_rewards;
+    total_rewards.staker_rewards = staker_rewards;
+    total_rewards.operator_rewards = operator_rewards;
+
+    Ok(())
+}

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -4,7 +4,9 @@ mod commit;
 mod join;
 mod launch;
 mod open_share;
+mod open_share_rewards;
 mod open_stake;
+mod open_total_rewards;
 mod stake;
 mod submit;
 mod unstake;
@@ -15,7 +17,9 @@ use commit::*;
 use join::*;
 use launch::*;
 use open_share::*;
+use open_share_rewards::process_open_share_rewards;
 use open_stake::*;
+use open_total_rewards::process_open_total_rewards;
 use stake::*;
 use submit::*;
 use unstake::*;
@@ -44,6 +48,8 @@ pub fn process_instruction(
         PoolInstruction::Launch => process_launch(accounts, data)?,
         PoolInstruction::OpenStake => process_open_stake(accounts, data)?,
         PoolInstruction::Submit => process_submit(accounts, data)?,
+        PoolInstruction::OpenTotalRewards => process_open_total_rewards(accounts, data)?,
+        PoolInstruction::OpenShareRewards => process_open_share_rewards(accounts, data)?,
     }
 
     Ok(())

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,6 +1,8 @@
 mod attribute;
 mod claim;
 mod commit;
+mod increment_share_rewards;
+mod increment_total_rewards;
 mod join;
 mod launch;
 mod open_share;
@@ -14,12 +16,14 @@ mod unstake;
 use attribute::*;
 use claim::*;
 use commit::*;
+use increment_share_rewards::*;
+use increment_total_rewards::*;
 use join::*;
 use launch::*;
 use open_share::*;
-use open_share_rewards::process_open_share_rewards;
+use open_share_rewards::*;
 use open_stake::*;
-use open_total_rewards::process_open_total_rewards;
+use open_total_rewards::*;
 use stake::*;
 use submit::*;
 use unstake::*;
@@ -50,6 +54,8 @@ pub fn process_instruction(
         PoolInstruction::Submit => process_submit(accounts, data)?,
         PoolInstruction::OpenTotalRewards => process_open_total_rewards(accounts, data)?,
         PoolInstruction::OpenShareRewards => process_open_share_rewards(accounts, data)?,
+        PoolInstruction::IncrementTotalRewards => process_increment_total_rewards(accounts, data)?,
+        PoolInstruction::IncrementShareRewards => process_increment_share_rewards(accounts, data)?,
     }
 
     Ok(())

--- a/program/src/open_share_rewards.rs
+++ b/program/src/open_share_rewards.rs
@@ -15,6 +15,7 @@ pub fn process_open_share_rewards(accounts: &[AccountInfo<'_>], data: &[u8]) -> 
     pool_info
         .to_account::<Pool>(&ore_pool_api::ID)?
         .check(|p| p.authority == *signer_info.key)?;
+    mint_info.to_mint()?;
     share_rewards_info.is_empty()?.is_writable()?.has_seeds(
         &[
             SHARE_REWARDS,

--- a/program/src/open_share_rewards.rs
+++ b/program/src/open_share_rewards.rs
@@ -1,0 +1,49 @@
+use ore_pool_api::consts::SHARE_REWARDS;
+use ore_pool_api::instruction::OpenShareRewards;
+use ore_pool_api::state::{Pool, ShareRewards};
+use steel::*;
+use steel::{AccountInfo, ProgramError, ProgramResult};
+
+pub fn process_open_share_rewards(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
+    // Parse args.
+    let args = OpenShareRewards::try_from_bytes(data)?;
+    // Load accounts.
+    let [signer_info, pool_info, mint_info, share_rewards_info, system_program] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+    signer_info.is_signer()?;
+    pool_info
+        .to_account::<Pool>(&ore_pool_api::ID)?
+        .check(|p| p.authority == *signer_info.key)?;
+    share_rewards_info.is_empty()?.is_writable()?.has_seeds(
+        &[
+            SHARE_REWARDS,
+            pool_info.key.as_ref(),
+            mint_info.key.as_ref(),
+        ],
+        args.bump,
+        &ore_pool_api::ID,
+    )?;
+    system_program.is_program(&system_program::ID)?;
+
+    // Create the share rewards pda.
+    create_account::<ShareRewards>(
+        share_rewards_info,
+        &ore_pool_api::ID,
+        &[
+            SHARE_REWARDS,
+            pool_info.key.as_ref(),
+            mint_info.key.as_ref(),
+            &[args.bump],
+        ],
+        system_program,
+        signer_info,
+    )?;
+
+    // Initialize share rewards account data.
+    let share_rewards = share_rewards_info.to_account_mut::<ShareRewards>(&ore_pool_api::ID)?;
+    share_rewards.pool = *pool_info.key;
+    share_rewards.mint = *mint_info.key;
+
+    Ok(())
+}

--- a/program/src/open_total_rewards.rs
+++ b/program/src/open_total_rewards.rs
@@ -1,0 +1,40 @@
+use ore_pool_api::{
+    consts::TOTAL_REWARDS,
+    instruction::OpenTotalRewards,
+    state::{Pool, TotalRewards},
+};
+use steel::*;
+
+pub fn process_open_total_rewards(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
+    // Parse args.
+    let args = OpenTotalRewards::try_from_bytes(data)?;
+    // Load accounts.
+    let [signer_info, pool_info, total_rewards_info, system_program] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+    signer_info.is_signer()?;
+    pool_info
+        .to_account::<Pool>(&ore_pool_api::ID)?
+        .check(|p| p.authority == *signer_info.key)?;
+    total_rewards_info.is_empty()?.is_writable()?.has_seeds(
+        &[TOTAL_REWARDS, pool_info.key.as_ref()],
+        args.bump,
+        &ore_pool_api::ID,
+    )?;
+    system_program.is_program(&system_program::ID)?;
+
+    // Create the total rewards pda.
+    create_account::<TotalRewards>(
+        total_rewards_info,
+        &ore_pool_api::ID,
+        &[TOTAL_REWARDS, pool_info.key.as_ref(), &[args.bump]],
+        system_program,
+        signer_info,
+    )?;
+
+    // Initialize total rewards account data.
+    let total_rewards = total_rewards_info.to_account_mut::<TotalRewards>(&ore_pool_api::ID)?;
+    total_rewards.pool = *pool_info.key;
+
+    Ok(())
+}

--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -21,7 +21,7 @@ pub fn create_pool() -> Pool {
 // have been incremented in the db but not yet on-chain
 pub async fn write_member_total_balances(
     conn: &mut Object,
-    increments: Vec<(String, u64)>,
+    increments: &[(String, u64)],
 ) -> Result<(), Error> {
     let transaction = conn.transaction().await?;
     for (address, increment) in increments.iter() {
@@ -260,7 +260,7 @@ pub async fn read_member(conn: &Object, address: &String) -> Result<ore_pool_typ
     })
 }
 
-async fn _write_total_rewards(
+pub async fn write_total_rewards(
     conn: &Object,
     pool: &Pubkey,
     miner_rewards_increment: u64,
@@ -272,7 +272,8 @@ async fn _write_total_rewards(
         "UPDATE total_rewards
         SET miner_rewards = miner_rewards + $1,
             staker_rewards = staker_rewards + $2,
-            operator_rewards = operator_rewards + $3
+            operator_rewards = operator_rewards + $3,
+            is_synced = false
         WHERE address = $4",
         &[
             &(miner_rewards_increment as i64),
@@ -285,7 +286,7 @@ async fn _write_total_rewards(
     Ok(())
 }
 
-async fn _write_share_rewards(
+pub async fn write_share_rewards(
     conn: &Object,
     pool: &Pubkey,
     mint: &Pubkey,
@@ -294,7 +295,8 @@ async fn _write_share_rewards(
     let (share_rewards_pda, _) = ore_pool_api::state::pool_share_rewards_pda(*pool, *mint);
     conn.execute(
         "UPDATE share_rewards
-        SET rewards = rewards + $1
+        SET rewards = rewards + $1,
+            is_synced = false
         WHERE address = $2",
         &[&(rewards_increment as i64), &share_rewards_pda.to_string()],
     )

--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -18,26 +18,6 @@ pub fn create_pool() -> Pool {
 /////////////////////////////////////////////////////////////////////////////////////////////
 /// write ///////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////
-pub async fn write_synced_total_rewards(conn: &Object, pool: &Pubkey) -> Result<(), Error> {
-    let (total_rewards_pda, _) = ore_pool_api::state::pool_total_rewards(*pool);
-    let query = "UPDATE total_rewards SET is_synced = true WHERE address = ANY($1)";
-    conn.execute(query, &[&total_rewards_pda.to_string()])
-        .await?;
-    Ok(())
-}
-
-pub async fn write_synced_share_rewards(
-    conn: &Object,
-    pool: &Pubkey,
-    mint: &Pubkey,
-) -> Result<(), Error> {
-    let (share_rewards_pda, _) = ore_pool_api::state::pool_share_rewards_pda(*pool, *mint);
-    let query = "UPDATE share_rewards SET is_synced = true WHERE address = ANY($1)";
-    conn.execute(query, &[&share_rewards_pda.to_string()])
-        .await?;
-    Ok(())
-}
-
 pub async fn write_synced_members(conn: &Object, address_buffer: &[String]) -> Result<(), Error> {
     let query = "UPDATE members SET is_synced = true WHERE address = ANY($1)";
     conn.execute(query, &[&address_buffer]).await?;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -7,7 +7,6 @@ mod tx;
 mod utils;
 mod webhook;
 
-use core::panic;
 use std::{collections::HashMap, sync::Arc};
 
 use actix_web::{get, middleware, web, App, HttpResponse, HttpServer, Responder};
@@ -81,7 +80,7 @@ async fn main() -> Result<(), error::Error> {
                         }
                     }
                     None => {
-                        panic!("rewards channel closed")
+                        log::error!("rewards channel closed")
                     }
                 };
             }
@@ -94,17 +93,17 @@ async fn main() -> Result<(), error::Error> {
         async move {
             loop {
                 {
-                    let operator = operator.clone();
                     // submit attributions
+                    let operator = operator.clone();
                     if let Err(err) = operator.into_inner().attribute_members().await {
-                        panic!("{:?}", err)
+                        log::error!("{:?}", err)
                     }
                 }
                 {
-                    let operator = operator.clone();
                     // submit reward increments
+                    let operator = operator.clone();
                     if let Err(err) = operator.into_inner().increment_rewards().await {
-                        panic!("{:?}", err)
+                        log::error!("{:?}", err)
                     }
                 }
                 // sleep until next epoch

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -93,10 +93,19 @@ async fn main() -> Result<(), error::Error> {
         let operator = operator.clone();
         async move {
             loop {
-                // submit attributions
-                let operator = operator.clone().into_inner();
-                if let Err(err) = operator.attribute_members().await {
-                    panic!("{:?}", err)
+                {
+                    let operator = operator.clone();
+                    // submit attributions
+                    if let Err(err) = operator.into_inner().attribute_members().await {
+                        panic!("{:?}", err)
+                    }
+                }
+                {
+                    let operator = operator.clone();
+                    // submit reward increments
+                    if let Err(err) = operator.into_inner().increment_rewards().await {
+                        panic!("{:?}", err)
+                    }
                 }
                 // sleep until next epoch
                 tokio::time::sleep(tokio::time::Duration::from_secs(60 * attribution_epoch)).await;

--- a/server/src/operator.rs
+++ b/server/src/operator.rs
@@ -268,6 +268,22 @@ impl Operator {
         vec
     }
 
+    pub async fn init_total_rewards(&self) -> Result<(), Error> {
+        let db_client = &self.db_client;
+        let db_client = db_client.get().await?;
+        let (pool_pda, _) = ore_pool_api::state::pool_pda(self.keypair.pubkey());
+        database::write_new_total_rewards(&db_client, &pool_pda).await?;
+        Ok(())
+    }
+
+    pub async fn init_share_rewards(&self, mint: &Pubkey) -> Result<(), Error> {
+        let db_client = &self.db_client;
+        let db_client = db_client.get().await?;
+        let (pool_pda, _) = ore_pool_api::state::pool_pda(self.keypair.pubkey());
+        database::write_new_share_rewards(&db_client, &pool_pda, mint).await?;
+        Ok(())
+    }
+
     fn get_boosts(&self) -> Vec<Pubkey> {
         let boost_accounts = &self.boost_accounts;
         boost_accounts.iter().map(|ba| ba.mint).collect()


### PR DESCRIPTION
Creates two new account types for pool operators.

1) Total Rewards
> this account tracks the lifetime rewards paid out by the pool, separated into three categories (miners, stakers, operator). disambiguates the pool yield amongst the three parties.

2) Share Rewards
> stakers (share holders) are contributing to many boost/stake accounts. one of these share-rewards accounts is created for each stake account the pool opens. it tracks the total yield paid out to share holders from a particular boost/stake account.

Incrementing these counts is negligible in terms of added transaction fees. The pool will need to land one additional transaction per attribution epoch, that touches 1 + 3 accounts. (1 total rewards + potentially 3 boost accounts). 

Disambiguating lifetime rewards allows indexers to compute interesting yield metrics.