### PR TITLE
Hashpower estimate via time series

### DIFF
--- a/server/src/aggregator.rs
+++ b/server/src/aggregator.rs
@@ -142,7 +142,7 @@ impl Aggregator {
             stake.insert(ba.mint, stakers);
         }
         // build self
-        let mut contributions = Miners::new(15);
+        let mut contributions = Miners::new(15 + 1);
         contributions.insert(challenge.lash_hash_at as u64);
         let aggregator = Aggregator {
             challenge,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2,7 +2,9 @@ mod aggregator;
 mod contributor;
 mod database;
 mod error;
+mod miner;
 mod operator;
+mod staker;
 mod tx;
 mod utils;
 mod webhook;
@@ -11,8 +13,10 @@ use core::panic;
 use std::{collections::HashMap, sync::Arc};
 
 use actix_web::{get, middleware, web, App, HttpResponse, HttpServer, Responder};
-use aggregator::{Aggregator, Contribution, Stakers};
+use aggregator::Aggregator;
+use miner::Contribution;
 use operator::Operator;
+use staker::Stakers;
 use utils::create_cors;
 
 // TODO: publish attestation to s3

--- a/server/src/miner.rs
+++ b/server/src/miner.rs
@@ -86,6 +86,7 @@ impl AttributionFilter {
     }
     pub fn push(&mut self, ts: LastHashAt) {
         if self.len.lt(&self.size) {
+            self.len += 1;
             self.time_stamps.push_back(ts);
         } else {
             self.time_stamps.pop_front();

--- a/server/src/miner.rs
+++ b/server/src/miner.rs
@@ -1,0 +1,132 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::hash::Hash;
+
+use drillx::Solution;
+use solana_sdk::pubkey::Pubkey;
+
+pub struct Miners {
+    pub miners: HashMap<LastHashAt, MinerContributions>,
+    attribution_filter: AttributionFilter,
+}
+
+impl Miners {
+    pub fn new(attribution_filter_size: u8) -> Self {
+        Self {
+            miners: HashMap::new(),
+            attribution_filter: AttributionFilter::new(attribution_filter_size),
+        }
+    }
+
+    pub fn insert(&mut self, ts: LastHashAt) {
+        let contributions = MinerContributions {
+            contributions: HashSet::new(),
+            winner: None,
+            total_score: 0,
+        };
+        if let Some(_) = self.miners.insert(ts, contributions) {
+            log::error!("contributions at last-hash-at already exist: {}", ts);
+        }
+        self.attribution_filter.push(ts);
+    }
+
+    pub fn scores(&mut self) -> (TotalScore, Vec<(Miner, u64)>) {
+        // filter for valid timestamps
+        self.filter();
+        // sum contribution scores for each member
+        let mut total_score: u64 = 0;
+        let mut merge: HashMap<Miner, u64> = HashMap::new();
+        let duplicates = self
+            .miners
+            .values()
+            .flat_map(|mc| mc.contributions.iter())
+            .map(|c| (c.member, c.score));
+        for (k, v) in duplicates {
+            *merge.entry(k).or_insert(0) += v;
+            total_score += v;
+        }
+        (total_score, merge.into_iter().collect())
+    }
+
+    fn filter(&mut self) {
+        let validation = &self.attribution_filter.time_stamps;
+        self.miners.retain(|k, _v| validation.contains(k));
+    }
+}
+
+/// miner authority
+pub type Miner = Pubkey;
+pub type TotalScore = u64;
+
+/// miner lookup table
+/// challenge --> contribution
+pub type LastHashAt = u64;
+pub struct MinerContributions {
+    pub contributions: HashSet<Contribution>,
+    pub winner: Option<Winner>,
+    pub total_score: u64,
+}
+
+/// timestamps of last n challenges
+pub struct AttributionFilter {
+    /// total num elements in vec
+    pub len: u8,
+    /// max size of vec
+    pub size: u8,
+    /// elements
+    pub time_stamps: VecDeque<LastHashAt>,
+}
+
+impl AttributionFilter {
+    pub fn new(size: u8) -> Self {
+        Self {
+            len: 0,
+            size,
+            time_stamps: VecDeque::with_capacity(size as usize),
+        }
+    }
+    pub fn push(&mut self, ts: LastHashAt) {
+        if self.len.lt(&self.size) {
+            self.time_stamps.push_back(ts);
+        } else {
+            self.time_stamps.pop_front();
+            self.time_stamps.push_back(ts);
+        }
+    }
+}
+
+/// Best hash to be submitted for the current challenge.
+#[derive(Clone, Copy, Debug)]
+pub struct Winner {
+    /// The winning solution.
+    pub solution: Solution,
+
+    /// The current largest difficulty.
+    pub difficulty: u32,
+}
+
+/// A recorded contribution from a particular member of the pool.
+#[derive(Clone, Copy, Debug)]
+pub struct Contribution {
+    /// The member who submitted this solution.
+    pub member: Pubkey,
+
+    /// The difficulty score of the solution.
+    pub score: u64,
+
+    /// The drillx solution submitted representing the member's best hash.
+    pub solution: Solution,
+}
+
+impl PartialEq for Contribution {
+    fn eq(&self, other: &Self) -> bool {
+        self.member == other.member
+    }
+}
+
+impl Eq for Contribution {}
+
+impl Hash for Contribution {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.member.hash(state);
+    }
+}

--- a/server/src/staker.rs
+++ b/server/src/staker.rs
@@ -1,0 +1,6 @@
+use solana_sdk::pubkey::Pubkey;
+use std::collections::HashMap;
+
+pub type BoostMint = Pubkey;
+pub type StakerBalances = HashMap<Pubkey, u64>;
+pub type Stakers = HashMap<BoostMint, StakerBalances>;


### PR DESCRIPTION
Observe contributions for N minutes. Smooths the attribution that client see and also helps precent sybil.