### PR TITLE
Continuous Submission

### DIFF
--- a/server/src/aggregator.rs
+++ b/server/src/aggregator.rs
@@ -170,7 +170,7 @@ impl Aggregator {
         let insert = contributions.contributions.replace(*contribution);
         match insert {
             Some(prev) => {
-                log::error!("updating contribution: {:?}", contribution.member);
+                log::info!("updating contribution: {:?}", contribution.member);
                 let difficulty = contribution.solution.to_hash().difficulty();
                 let contender = Winner {
                     solution: contribution.solution,
@@ -192,7 +192,7 @@ impl Aggregator {
                 Ok(())
             }
             None => {
-                log::error!("new contribution: {:?}", contribution.member);
+                log::info!("new contribution: {:?}", contribution.member);
                 let difficulty = contribution.solution.to_hash().difficulty();
                 let contender = Winner {
                     solution: contribution.solution,

--- a/server/src/aggregator.rs
+++ b/server/src/aggregator.rs
@@ -21,7 +21,7 @@ use crate::{
 
 /// The client submits slightly earlier
 /// than the operator's cutoff time to create a "submission window".
-pub const BUFFER_CLIENT: u64 = 2 + BUFFER_OPERATOR;
+pub const BUFFER_CLIENT: u64 = 0 + BUFFER_OPERATOR;
 const MAX_DIFFICULTY: u32 = 22;
 const MAX_SCORE: u64 = 2u64.pow(MAX_DIFFICULTY);
 
@@ -167,15 +167,20 @@ impl Aggregator {
             return Err(Error::Internal("invalid solution".to_string()));
         }
         // insert
-        let insert = contributions.contributions.insert(*contribution);
+        let insert = contributions.contributions.replace(*contribution);
         match insert {
-            true => {
+            Some(prev) => {
+                log::error!("updating contribution: {:?}", contribution.member);
                 let difficulty = contribution.solution.to_hash().difficulty();
                 let contender = Winner {
                     solution: contribution.solution,
                     difficulty,
                 };
+                // decrement previous score
+                contributions.total_score -= prev.score;
+                // increment new score
                 contributions.total_score += contribution.score;
+                // update winner
                 match contributions.winner {
                     Some(winner) => {
                         if difficulty > winner.difficulty {
@@ -186,8 +191,24 @@ impl Aggregator {
                 }
                 Ok(())
             }
-            false => {
-                log::error!("already received contribution: {:?}", contribution.member);
+            None => {
+                log::error!("new contribution: {:?}", contribution.member);
+                let difficulty = contribution.solution.to_hash().difficulty();
+                let contender = Winner {
+                    solution: contribution.solution,
+                    difficulty,
+                };
+                // increment score
+                contributions.total_score += contribution.score;
+                // update winner
+                match contributions.winner {
+                    Some(winner) => {
+                        if difficulty > winner.difficulty {
+                            contributions.winner = Some(contender);
+                        }
+                    }
+                    None => contributions.winner = Some(contender),
+                }
                 Ok(())
             }
         }

--- a/server/src/operator.rs
+++ b/server/src/operator.rs
@@ -19,7 +19,7 @@ use steel::AccountDeserialize;
 use crate::{database, error::Error, tx};
 
 pub const BUFFER_OPERATOR: u64 = 5;
-const MIN_DIFFICULTY: Option<u64> = None;
+const MIN_DIFFICULTY: Option<u64> = Some(7);
 
 pub struct Operator {
     /// The pool authority keypair.


### PR DESCRIPTION
Accept continuous submissions from the client. Clients submit every incremental solution as they improve. Maximizes the client submission window [0, SERVER_BUFFER] instead of [CLIENT_BUFFER, SERVER_BUFFER] where client-buffer is some constant less than the server buffer (was hard-coded to 2 seconds).