### PR TITLE
Drop rate limiter on register

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,19 +45,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-extensible-rate-limit"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f69685bde52e3c1d9ec47aa42ae4eca7f27c04661774423b68b26a06757181"
-dependencies = [
- "actix-web",
- "dashmap 6.1.0",
- "futures",
- "log",
- "thiserror",
-]
-
-[[package]]
 name = "actix-http"
 version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,20 +1348,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -3050,7 +3023,6 @@ name = "ore-pool-server"
 version = "0.0.1"
 dependencies = [
  "actix-cors",
- "actix-extensible-rate-limit",
  "actix-web",
  "base64 0.22.1",
  "bincode",
@@ -4155,7 +4127,7 @@ checksum = "24a9f32c42402c4b9484d5868ac74b7e0a746e3905d8bfd756e1203e50cbb87e"
 dependencies = [
  "async-trait",
  "bincode",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "futures-util",
  "indexmap 2.6.0",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -33,4 +33,3 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-postgres = { workspace = true }
 rand = "0.8.5"
-actix-extensible-rate-limit = "0.4.0"


### PR DESCRIPTION
The `/register` path is idempotent. It will return the db member account, if it exists already. And it will only exist in the db, if the on-chain account already exists.

The server was checking for the on-chain account first, and then the db account. This was causing problems with massively parallel clients who were hitting this path to fetch the db member account.

Initially, we "solved" this problem by applying rate limiting here in the server middleware. The more correct approach is to check the DB first, and then the on-chain account. That'll scale for clients that are behaving in good faith.

For clients that are behaving in bad faith (legit DDOS), rate limiting should be applied at the networking layer, not the app middleware layer.