### PR TITLE
Multiple Devices Same Keypair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2944,9 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "ore-api"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8dd8451eeb0592e30a3c59c7b4721e73b40a80bb749e9d993abadf29fb12099"
+version = "2.7.0"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",
@@ -2965,8 +2963,6 @@ dependencies = [
 [[package]]
 name = "ore-boost-api"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce6c36c89d829a4b36debc127625513aaf668ed8f0eb4982493fdc3b6b004e9"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2945,6 +2945,8 @@ dependencies = [
 [[package]]
 name = "ore-api"
 version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7610924995b6efe0f010a03b6451da906a3724f1b0f4ea873693be2e9e4d23bc"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",
@@ -2963,6 +2965,8 @@ dependencies = [
 [[package]]
 name = "ore-boost-api"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce6c36c89d829a4b36debc127625513aaf668ed8f0eb4982493fdc3b6b004e9"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ futures-util = "0.3"
 log = "0.4"
 mpl-token-metadata = "4.1.2"
 num_enum = "0.7.2"
-ore-api = "2.5"
+ore-api = "2.7"
 ore-boost-api = "0.3"
 ore-pool-api = { path = "api", version = "0.2.0" }
 ore-pool-types = { path = "types", version = "0.2.0" }
@@ -52,6 +52,6 @@ thiserror = "1.0.57"
 tokio = "1.39"
 tokio-postgres = "0.7"
 
-# [patch.crates-io]
-# ore-api = { path = "../ore/api" }
-# ore-boost-api = { path = "../ore-boost/api" }
+[patch.crates-io]
+ore-api = { path = "../ore/api" }
+ore-boost-api = { path = "../ore-boost/api" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,6 @@ thiserror = "1.0.57"
 tokio = "1.39"
 tokio-postgres = "0.7"
 
-[patch.crates-io]
-ore-api = { path = "../ore/api" }
-ore-boost-api = { path = "../ore-boost/api" }
+# [patch.crates-io]
+# ore-api = { path = "../ore/api" }
+# ore-boost-api = { path = "../ore-boost/api" }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -18,4 +18,4 @@ pub mod prelude {
 
 use steel::*;
 
-declare_id!("APwnwBuRtLAN1Qk1fuZ5beXKfA5Efe9jK2ECd4c9o3E");
+declare_id!("poo1sKMYsZtDDS7og73L68etJQYyn6KXhXTLz1hizJc");

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -18,4 +18,4 @@ pub mod prelude {
 
 use steel::*;
 
-declare_id!("poo1sKMYsZtDDS7og73L68etJQYyn6KXhXTLz1hizJc");
+declare_id!("APwnwBuRtLAN1Qk1fuZ5beXKfA5Efe9jK2ECd4c9o3E");

--- a/server/src/aggregator.rs
+++ b/server/src/aggregator.rs
@@ -168,7 +168,6 @@ impl Aggregator {
         match insert {
             Some(prev) => {
                 if contribution.score.gt(&prev.score) {
-                    log::info!("updating contribution: {:?}", contribution.member);
                     let difficulty = contribution.solution.to_hash().difficulty();
                     let contender = Winner {
                         solution: contribution.solution,

--- a/server/src/aggregator.rs
+++ b/server/src/aggregator.rs
@@ -167,24 +167,26 @@ impl Aggregator {
         let insert = contributions.contributions.replace(*contribution);
         match insert {
             Some(prev) => {
-                log::info!("updating contribution: {:?}", contribution.member);
-                let difficulty = contribution.solution.to_hash().difficulty();
-                let contender = Winner {
-                    solution: contribution.solution,
-                    difficulty,
-                };
-                // decrement previous score
-                contributions.total_score -= prev.score;
-                // increment new score
-                contributions.total_score += contribution.score;
-                // update winner
-                match contributions.winner {
-                    Some(winner) => {
-                        if difficulty > winner.difficulty {
-                            contributions.winner = Some(contender);
+                if contribution.score.gt(&prev.score) {
+                    log::info!("updating contribution: {:?}", contribution.member);
+                    let difficulty = contribution.solution.to_hash().difficulty();
+                    let contender = Winner {
+                        solution: contribution.solution,
+                        difficulty,
+                    };
+                    // decrement previous score
+                    contributions.total_score -= prev.score;
+                    // increment new score
+                    contributions.total_score += contribution.score;
+                    // update winner
+                    match contributions.winner {
+                        Some(winner) => {
+                            if difficulty > winner.difficulty {
+                                contributions.winner = Some(contender);
+                            }
                         }
+                        None => contributions.winner = Some(contender),
                     }
-                    None => contributions.winner = Some(contender),
                 }
                 Ok(())
             }

--- a/server/src/aggregator.rs
+++ b/server/src/aggregator.rs
@@ -266,11 +266,11 @@ impl Aggregator {
         let current_devices = all_devices
             .entry((*last_hash_at) as u64)
             .or_insert(new_devices);
-        // lookup miner devices against current challenge
-        let miner_devices = current_devices.entry(miner).or_insert(0);
-        // increment device index
-        *miner_devices += 1;
-        *miner_devices
+        // lookup miner device id against current challenge
+        let device_id = current_devices.entry(miner).or_insert(0);
+        // increment device id
+        *device_id += 1;
+        *device_id
     }
 
     pub async fn distribute_rewards(

--- a/server/src/contributor.rs
+++ b/server/src/contributor.rs
@@ -12,6 +12,8 @@ use crate::{
     aggregator::Aggregator, database, error::Error, operator::Operator, tx, webhook, Contribution,
 };
 
+const NUM_CLIENT_DEVICES: u8 = 5;
+
 ////////////////////////////////////////////////////////////////////////////////////
 /// HTTP HANDLERS //////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////
@@ -128,6 +130,7 @@ pub async fn challenge_v2(
         challenge,
         num_total_members: last_num_members,
         device_id,
+        num_devices: NUM_CLIENT_DEVICES,
     };
     HttpResponse::Ok().json(&member_challenge)
 }

--- a/server/src/contributor.rs
+++ b/server/src/contributor.rs
@@ -1,16 +1,15 @@
+use std::str::FromStr;
+
 use actix_web::{web, HttpResponse, Responder};
 use ore_pool_types::{
-    BalanceUpdate, ContributePayload, GetMemberPayload, MemberChallenge, PoolAddress,
-    RegisterPayload, RegisterStakerPayload, Staker, UpdateBalancePayload,
+    BalanceUpdate, ContributePayload, GetChallengePayload, GetMemberPayload, MemberChallenge,
+    MemberChallengeV2, PoolAddress, RegisterPayload, RegisterStakerPayload, Staker,
+    UpdateBalancePayload,
 };
 use solana_sdk::{pubkey::Pubkey, signer::Signer};
 
 use crate::{
-    aggregator::{Aggregator, BUFFER_CLIENT},
-    database,
-    error::Error,
-    operator::Operator,
-    tx, webhook, Contribution,
+    aggregator::Aggregator, database, error::Error, operator::Operator, tx, webhook, Contribution,
 };
 
 ////////////////////////////////////////////////////////////////////////////////////
@@ -93,7 +92,6 @@ pub async fn member(
     }
 }
 
-// TODO: consider the need for auth on this get/read?
 pub async fn challenge(aggregator: web::Data<tokio::sync::RwLock<Aggregator>>) -> impl Responder {
     // acquire read on aggregator for challenge
     let (challenge, last_num_members) = {
@@ -103,8 +101,33 @@ pub async fn challenge(aggregator: web::Data<tokio::sync::RwLock<Aggregator>>) -
     // build member challenge
     let member_challenge = MemberChallenge {
         challenge,
-        buffer: BUFFER_CLIENT,
+        buffer: 0,
         num_total_members: last_num_members,
+    };
+    HttpResponse::Ok().json(&member_challenge)
+}
+
+pub async fn challenge_v2(
+    aggregator: web::Data<tokio::sync::RwLock<Aggregator>>,
+    path: web::Path<GetChallengePayload>,
+) -> impl Responder {
+    let miner = match Pubkey::from_str(path.authority.as_str()) {
+        Ok(authority) => authority,
+        Err(err) => {
+            return HttpResponse::BadRequest().body(err.to_string());
+        }
+    };
+    // acquire write on aggregator for challenge
+    let (challenge, last_num_members, device_id) = {
+        let mut aggregator = aggregator.write().await;
+        let device_id = aggregator.get_device_id(miner);
+        (aggregator.challenge, aggregator.num_members, device_id)
+    };
+    // build member challenge
+    let member_challenge = MemberChallengeV2 {
+        challenge,
+        num_total_members: last_num_members,
+        device_id,
     };
     HttpResponse::Ok().json(&member_challenge)
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -135,6 +135,10 @@ async fn main() -> Result<(), error::Error> {
             .service(web::resource("/contribute").route(web::post().to(contributor::contribute)))
             .service(web::resource("/challenge").route(web::get().to(contributor::challenge)))
             .service(
+                web::resource("/challenge/{authority}")
+                    .route(web::get().to(contributor::challenge_v2)),
+            )
+            .service(
                 web::resource("/update-balance").route(web::post().to(contributor::update_balance)),
             )
             .service(

--- a/server/src/miner.rs
+++ b/server/src/miner.rs
@@ -6,6 +6,7 @@ use solana_sdk::pubkey::Pubkey;
 
 pub struct Miners {
     pub miners: HashMap<LastHashAt, MinerContributions>,
+    pub devices: HashMap<LastHashAt, Devices>,
     attribution_filter: AttributionFilter,
 }
 
@@ -13,6 +14,7 @@ impl Miners {
     pub fn new(attribution_filter_size: u8) -> Self {
         Self {
             miners: HashMap::new(),
+            devices: HashMap::new(),
             attribution_filter: AttributionFilter::new(attribution_filter_size),
         }
     }
@@ -50,12 +52,16 @@ impl Miners {
     fn filter(&mut self) {
         let validation = &self.attribution_filter.time_stamps;
         self.miners.retain(|k, _v| validation.contains(k));
+        self.devices.retain(|k, _v| validation.contains(k));
     }
 }
 
 /// miner authority
 pub type Miner = Pubkey;
-pub type TotalScore = u64;
+
+/// miner devices
+pub type DeviceIndex = u8;
+pub type Devices = HashMap<Miner, DeviceIndex>;
 
 /// miner lookup table
 /// challenge --> contribution
@@ -65,6 +71,9 @@ pub struct MinerContributions {
     pub winner: Option<Winner>,
     pub total_score: u64,
 }
+
+/// total score per challenge
+pub type TotalScore = u64;
 
 /// timestamps of last n challenges
 pub struct AttributionFilter {

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -154,6 +154,9 @@ pub struct MemberChallengeV2 {
 
     /// The id/index for distinguishing devices the client is using.
     pub device_id: u8,
+
+    /// The number of client devices permitted per member.
+    pub num_devices: u8,
 }
 
 /// The response from the update-balance request.

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -17,6 +17,12 @@ pub struct GetMemberPayload {
     pub authority: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct GetChallengePayload {
+    /// The authority of the member account sending the payload.
+    pub authority: String,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ContributePayload {
     /// The authority of the member account sending the payload.
@@ -135,6 +141,19 @@ pub struct MemberChallenge {
 
     /// The number of total members to divide the nonce space by.
     pub num_total_members: u64,
+}
+
+/// The response from the /challenge request.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MemberChallengeV2 {
+    /// The challenge to mine for.
+    pub challenge: Challenge,
+
+    /// The number of total members to divide the nonce space by.
+    pub num_total_members: u64,
+
+    /// The id/index for distinguishing devices the client is using.
+    pub device_id: u8,
 }
 
 /// The response from the update-balance request.


### PR DESCRIPTION
Mining from multiple devices with the same keypair.

The `ore-cli` client will submit solutions for ~55 seconds per challenge (by default). It will then poll in a loop for a *new* challenge from the pool, distinguishing from the previous challenge by the `.last_hash_at` field.

When the client finds the new challenge, it'll stop polling and start mining again. This means that if the client polls more than once for a particular challenge, it's already submitted its solution(s) and is actually just polling for the next challenge.

This implementation tracks the number of polling requests from each client pubkey, per challenge. The initial N requests/polls imply there are N devices with the same keypair mining.

Critically, this impl does not require clients to "connect" with a uuid and then "disconnect", which would not work with the REST HTTP client/server relationship we have right now.

This impl introduces a new `MemberChallengeV2` type and will require a `minor version` release of the `ore-pool-types` crate, preserving backwards compatibility.

