### PR TITLE
Deprecate device ID assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "admin"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "ore-api",
  "ore-boost-api 1.1.0",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "ore-pool-api"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "ore-pool-program"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytemuck",
@@ -3245,7 +3245,7 @@ dependencies = [
 
 [[package]]
 name = "ore-pool-types"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "drillx",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["admin", "api", "program", "server", "types"]
 
 [workspace.package]
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://ore.supply"

--- a/server/src/aggregator.rs
+++ b/server/src/aggregator.rs
@@ -11,7 +11,7 @@ use solana_sdk::{pubkey::Pubkey, signer::Signer};
 use steel::AccountDeserialize;
 
 use crate::{
-    contributions::{Contribution, Contributions, Devices, Miner, MinerContributions, PoolMiningEvent, RecentEvents, Winner}, database, error::Error, operator::Operator, tx
+    contributions::{Contribution, Contributions, MinerContributions, PoolMiningEvent, RecentEvents, Winner}, database, error::Error, operator::Operator, tx
 };
 
 const MAX_DIFFICULTY: u32 = 22;
@@ -270,23 +270,23 @@ impl Aggregator {
         Ok(())
     }
 
-    pub fn get_device_id(&mut self, miner: Miner) -> u8 {
-        // get device indices at current challenge
-        let last_hash_at = &self.current_challenge.lash_hash_at;
-        let all_devices = &mut self.contributions.devices;
-        let mut new_devices: Devices = HashMap::new();
-        new_devices.insert(miner, 0);
-        let current_devices = all_devices
-            .entry((*last_hash_at) as u64)
-            .or_insert(new_devices);
+    // pub fn get_device_id(&mut self, miner: Miner) -> u8 {
+    //     // get device indices at current challenge
+    //     let last_hash_at = &self.current_challenge.lash_hash_at;
+    //     let all_devices = &mut self.contributions.devices;
+    //     let mut new_devices: Devices = HashMap::new();
+    //     new_devices.insert(miner, 0);
+    //     let current_devices = all_devices
+    //         .entry((*last_hash_at) as u64)
+    //         .or_insert(new_devices);
 
-        // lookup miner device id against current challenge
-        let device_id = current_devices.entry(miner).or_insert(0);
+    //     // lookup miner device id against current challenge
+    //     let device_id = current_devices.entry(miner).or_insert(0);
 
-        // increment device id
-        *device_id += 1;
-        *device_id
-    }
+    //     // increment device id
+    //     *device_id += 1;
+    //     *device_id
+    // }
 
     pub async fn distribute_rewards(
         &mut self,

--- a/server/src/aggregator.rs
+++ b/server/src/aggregator.rs
@@ -270,24 +270,6 @@ impl Aggregator {
         Ok(())
     }
 
-    // pub fn get_device_id(&mut self, miner: Miner) -> u8 {
-    //     // get device indices at current challenge
-    //     let last_hash_at = &self.current_challenge.lash_hash_at;
-    //     let all_devices = &mut self.contributions.devices;
-    //     let mut new_devices: Devices = HashMap::new();
-    //     new_devices.insert(miner, 0);
-    //     let current_devices = all_devices
-    //         .entry((*last_hash_at) as u64)
-    //         .or_insert(new_devices);
-
-    //     // lookup miner device id against current challenge
-    //     let device_id = current_devices.entry(miner).or_insert(0);
-
-    //     // increment device id
-    //     *device_id += 1;
-    //     *device_id
-    // }
-
     pub async fn distribute_rewards(
         &mut self,
         operator: &Operator,

--- a/server/src/contributions.rs
+++ b/server/src/contributions.rs
@@ -7,7 +7,6 @@ use solana_sdk::signature::Signature;
 
 pub struct Contributions {
     pub miners: HashMap<LastHashAt, MinerContributions>,
-    pub devices: HashMap<LastHashAt, Devices>,
     attribution_filter: AttributionFilter,
 }
 
@@ -15,7 +14,6 @@ impl Contributions {
     pub fn new(attribution_filter_size: u8) -> Self {
         Self {
             miners: HashMap::new(),
-            devices: HashMap::new(),
             attribution_filter: AttributionFilter::new(attribution_filter_size),
         }
     }
@@ -54,16 +52,11 @@ impl Contributions {
     fn filter(&mut self) {
         let validation = &self.attribution_filter.time_stamps;
         self.miners.retain(|k, _v| validation.contains(k));
-        self.devices.retain(|k, _v| validation.contains(k));
     }
 }
 
 /// miner authority
 pub type Miner = Pubkey;
-
-/// miner devices
-pub type DeviceIndex = u8;
-pub type Devices = HashMap<Miner, DeviceIndex>;
 
 /// miner lookup table
 /// challenge --> contribution

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -101,6 +101,7 @@ async fn main() -> Result<(), error::Error> {
             .app_data(aggregator.clone())
             .app_data(events_tx.clone())
             .service(web::resource("/address").route(web::get().to(handlers::address)))
+            .service(web::resource("/challenge").route(web::get().to(handlers::challenge)))
             .service(web::resource("/challenge/{authority}").route(web::get().to(handlers::challenge)))
             .service(web::resource("/contribute").route(web::post().to(handlers::contribute)))
             .service(web::resource("/commit").route(web::post().to(handlers::commit_balance)))

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -149,6 +149,7 @@ pub struct MemberChallenge {
     pub num_total_members: u64,
 
     /// The id/index for distinguishing devices the client is using.
+    #[deprecated(since = "1.2.0", note = "The pool server no longer automatically assigns device IDs. Miners should set their device IDs manually.")]
     pub device_id: u8,
 
     /// The number of client devices permitted per member.


### PR DESCRIPTION
Automated device ID assignment is creating too many edge cases in pool-client communication. This change deprecates the process by which pool servers would automatically assign a device ID in favor of a system where the user manually sets the device ID on the client. 