### PR TITLE
Deprecate bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "admin"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "ore-api",
  "ore-boost-api 1.1.0",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "ore-pool-api"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "ore-pool-program"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "base64 0.22.1",
  "bytemuck",
@@ -3245,7 +3245,7 @@ dependencies = [
 
 [[package]]
 name = "ore-pool-types"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "drillx",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["admin", "api", "program", "server", "types"]
 
 [workspace.package]
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://ore.supply"

--- a/api/src/instruction.rs
+++ b/api/src/instruction.rs
@@ -32,6 +32,7 @@ pub struct Attribute {
 #[derive(Clone, Copy, Debug, Pod, Zeroable)]
 pub struct Claim {
     pub amount: [u8; 8],
+    #[deprecated(since = "0.1.3", note = "Bumps are no longer required")]
     pub pool_bump: u8,
 }
 
@@ -43,7 +44,9 @@ pub struct Commit {}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod, Zeroable)]
 pub struct Launch {
+    #[deprecated(since = "0.1.3", note = "Bumps are no longer required")]
     pub pool_bump: u8,
+    #[deprecated(since = "0.1.3", note = "Bumps are no longer required")]
     pub proof_bump: u8,
     pub url: [u8; 128],
 }
@@ -63,6 +66,7 @@ pub struct OpenStake {}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod, Zeroable)]
 pub struct Join {
+    #[deprecated(since = "0.1.3", note = "Bumps are no longer required")]
     pub member_bump: u8,
 }
 

--- a/api/src/sdk.rs
+++ b/api/src/sdk.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 /// Builds a launch instruction.
+#[allow(deprecated)]
 pub fn launch(signer: Pubkey, miner: Pubkey, url: String) -> Result<Instruction, ApiError> {
     let url = url_to_bytes(url.as_str())?;
     let (pool_pda, pool_bump) = pool_pda(signer);
@@ -40,6 +41,7 @@ pub fn launch(signer: Pubkey, miner: Pubkey, url: String) -> Result<Instruction,
 }
 
 /// Builds an join instruction.
+#[allow(deprecated)]
 pub fn join(member_authority: Pubkey, pool: Pubkey, payer: Pubkey) -> Instruction {
     let (member_pda, member_bump) = member_pda(member_authority, pool);
     Instruction {
@@ -56,11 +58,11 @@ pub fn join(member_authority: Pubkey, pool: Pubkey, payer: Pubkey) -> Instructio
 }
 
 /// Builds a claim instruction.
+#[allow(deprecated)]
 pub fn claim(
     signer: Pubkey,
     beneficiary: Pubkey,
     pool_address: Pubkey,
-    pool_bump: u8,
     amount: u64,
 ) -> Instruction {
     let (member_pda, _) = member_pda(signer, pool_address);
@@ -80,7 +82,7 @@ pub fn claim(
         ],
         data: Claim {
             amount: amount.to_le_bytes(),
-            pool_bump,
+            pool_bump: 0,
         }
         .to_bytes(),
     }

--- a/api/src/state/pool.rs
+++ b/api/src/state/pool.rs
@@ -10,6 +10,7 @@ pub struct Pool {
     pub authority: Pubkey,
 
     /// The bump used for signing CPIs.
+    #[deprecated(since = "0.1.3", note = "Bumps are no longer required")]
     pub bump: u64,
 
     /// The url where hashes should be submitted (right padded with 0s).

--- a/program/src/claim.rs
+++ b/program/src/claim.rs
@@ -36,7 +36,7 @@ pub fn process_claim(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult
 
     // Claim tokens to the beneficiary
     let pool_authority = pool.authority;
-    solana_program::program::invoke_signed(
+    invoke_signed(
         &ore_api::sdk::claim(*pool_info.key, *beneficiary_info.key, amount),
         &[
             pool_info.clone(),
@@ -46,7 +46,8 @@ pub fn process_claim(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult
             treasury_tokens_info.clone(),
             token_program.clone(),
         ],
-        &[&[POOL, pool_authority.as_ref(), &[args.pool_bump]]],
+        &ore_pool_api::ID,
+        &[POOL, pool_authority.as_ref()],
     )?;
 
     Ok(())

--- a/program/src/unstake.rs
+++ b/program/src/unstake.rs
@@ -58,7 +58,7 @@ pub fn process_unstake(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResu
 
     // Withdraw remaining amount from staked balance.
     if withdraw_amount.gt(&0) {
-        solana_program::program::invoke_signed(
+        invoke_signed(
             &ore_boost_legacy_api::sdk::withdraw(*pool_info.key, *mint_info.key, withdraw_amount),
             &[
                 pool_info.clone(),
@@ -69,7 +69,8 @@ pub fn process_unstake(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResu
                 stake_info.clone(),
                 token_program.clone(),
             ],
-            &[&[POOL, pool.authority.as_ref(), &[pool.bump as u8]]],
+            &ore_pool_api::ID,
+            &[POOL, pool.authority.as_ref()],
         )?;
     }
 


### PR DESCRIPTION
- Bumps have been unnecessary since Steel v2.0.
- Deprecate all bumps in API and migrate to Steel CPIs